### PR TITLE
No longer need RStudio "preview release"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using **rticles** has some prerequisites which are described below. You can get 
 
 To use **rticles** from RStudio:
 
-1) Install the latest [RStudio](http://www.rstudio.com/ide/download).
+1) Install the latest [RStudio](http://www.rstudio.com/products/rstudio/download/).
 
 2) Install the **rticles** package: 
 


### PR DESCRIPTION
Also changed URL from http://www.rstudio.com/ide/download to http://www.rstudio.com/products/rstudio/download.
