### PR TITLE
use UTF-8 as input encoding

### DIFF
--- a/inst/rmarkdown/templates/acm/resources/template.tex
+++ b/inst/rmarkdown/templates/acm/resources/template.tex
@@ -1,4 +1,5 @@
 \documentclass{acm_proc_article-sp}
+\usepackage[utf8]{inputenc}
 
 \renewcommand{\paragraph}[1]{\vskip 6pt\noindent\textbf{#1 }}
 \usepackage{hyperref}

--- a/inst/rmarkdown/templates/acs/resources/template.tex
+++ b/inst/rmarkdown/templates/acs/resources/template.tex
@@ -1,4 +1,5 @@
 \documentclass[journal=$journal$,manuscript=$type$]{achemso}
+\usepackage[utf8]{inputenc}
 \usepackage[version=3]{mhchem}
 \usepackage{amsmath}
 \newcommand*\mycommand[1]{\texttt{\emph{#1}}}

--- a/inst/rmarkdown/templates/jss_article/resources/template.tex
+++ b/inst/rmarkdown/templates/jss_article/resources/template.tex
@@ -1,4 +1,5 @@
 \documentclass[article]{jss}
+\usepackage[utf8]{inputenc}
 
 \author{
 $for(author)$$author.name$\\$author.affiliation$$sep$ \And $endfor$

--- a/inst/rmarkdown/templates/plos_article/resources/template.tex
+++ b/inst/rmarkdown/templates/plos_article/resources/template.tex
@@ -1,6 +1,7 @@
 % Template for PLoS
 
 \documentclass[10pt]{article}
+\usepackage[utf8]{inputenc}
 
 % amsmath package, useful for mathematical formulas
 \usepackage{amsmath}

--- a/inst/rmarkdown/templates/use_r_abstract/resources/template.tex
+++ b/inst/rmarkdown/templates/use_r_abstract/resources/template.tex
@@ -1,4 +1,5 @@
 \documentclass[11pt, a4paper]{article}
+\usepackage[utf8]{inputenc}
 \usepackage{amsfonts, amsmath, hanging, hyperref, parskip, times}
 \usepackage[numbers]{natbib}
 \usepackage[pdftex]{graphicx}


### PR DESCRIPTION
For consistency. I'm not sure if this is really allowed by the affected journals -- if not, we might need to look for another solution, as pandoc will create UTF-8 anyway.