### PR TITLE
Sensible defaults for figures in JSS paper

### DIFF
--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -11,6 +11,11 @@ jss_article <- function() {
   base$knitr$opts_chunk$comment <- NA
   base$knitr$opts_chunk$highlight <- FALSE
 
+  base$knitr$opts_chunk$dev.args <- list(pointsize = 11)
+  base$knitr$opts_chunk$fig.width <- 4.9 # 6.125" * 0.8, as in template
+  base$knitr$opts_chunk$fig.height <- 3.675 # 4.9 * 3:4
+  base$knitr$opts_chunk$fig.align <- "center"
+
   hook_chunk <- function(x, options) {
     if (knitr:::output_asis(x, options)) return(x)
     paste0('\\begin{CodeChunk}\n', x, '\\end{CodeChunk}')


### PR DESCRIPTION
The LaTeX template scales the figures to 80% of the text width, which is [defined](https://github.com/rstudio/rticles/blob/master/inst/rmarkdown/templates/jss_article/skeleton/jss.cls#L75) as 6.125". For best results, figures should be inserted using their natural size. In addition, figures are centered, and the pointsize device option is set to match the point size of the document.