### PR TITLE
Fix unwanted space in authors list

### DIFF
--- a/inst/rmarkdown/templates/rjournal_article/resources/template.tex
+++ b/inst/rmarkdown/templates/rjournal_article/resources/template.tex
@@ -5,7 +5,7 @@
 \maketitle
 
 $if(abstract)$
-\abstract{
+\abstract{%
 $abstract$
 }
 $endif$
@@ -13,7 +13,7 @@ $endif$
 $body$
 
 $for(author)$
-\address{
+\address{%
 $author.name$\\
 $author.affiliation$\\
 $for(author.address)$$author.address$$sep$\\ $endfor$\\


### PR DESCRIPTION
In general, latex commands of the form
```
\foo{
```
Should be replaced with
```
\foo{%
```
to avoid an unwanted whitespace token getting inserted.

I've fixed this in the R Journal article template since it was causing the authors names to be preceded by an unwanted space.  This issue may affect other templates, but I haven't used them.