### PR TITLE
Fix broken link

### DIFF
--- a/inst/rmarkdown/templates/rjournal_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/rjournal_article/skeleton/skeleton.Rmd
@@ -47,6 +47,5 @@ x
 
 ## Summary
 
-This file is only a basic article template. For full details of _The R Journal_ style and information on how to prepare your article for submission, see the [Instructions for Authors](http://journal.r-project.org/latex/RJauthorguide.pdf).
-
+This file is only a basic article template. For full details of _The R Journal_ style and information on how to prepare your article for submission, see the [Instructions for Authors](https://journal.r-project.org/share/author-guide.pdf).
 \bibliography{RJreferences}


### PR DESCRIPTION
It seems that the author guide location on the R Journal website has moved. This modifies the skeleton to point to the correct link.