### PR TITLE
Add address and footnote examples to Elsevier skeleton.

### DIFF
--- a/inst/rmarkdown/templates/elsevier_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/elsevier_article/skeleton/skeleton.Rmd
@@ -4,9 +4,15 @@ author:
   - name: Alice Anonymous
     email: alice@example.com
     affiliation: Some Institute of Technology
+    footnote: Corresponding Author
   - name: Bob Security
     email: bob@example.com
     affiliation: Another University
+address:
+  - code: Some Institute of Technology
+    address: Department, Street, City, State, Zip
+  - code: Another University
+    address: Department, Street, City, State, Zip
 abstract: |
   This is the abstract.
 


### PR DESCRIPTION
Updates Elsevier skeleton to add `address` and `footnote` examples.

See https://github.com/rstudio/rticles/issues/64