### PR TITLE
Add \tightlist macro to elsevier format

### DIFF
--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -5,6 +5,9 @@
 $if(linenumbers)$
   \linenumbers % turns line numbering on
 $endif$
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 \bibliographystyle{elsarticle-harv}
 \biboptions{sort&compress} % For natbib
 \usepackage{graphicx}


### PR DESCRIPTION
This is required for compatibility with pandoc >= 1.14.

This fix complements d1fa8547660d3d2fa68f9b4998c1e0bde0b1eb35