### PR TITLE
Fix issue 61 and part of 71

### DIFF
--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -35,12 +35,17 @@ jss_article <- function(..., keep_tex = TRUE) {
   base$knitr$opts_chunk$fig.width <- 4.9 # 6.125" * 0.8, as in template
   base$knitr$opts_chunk$fig.height <- 3.675 # 4.9 * 3:4
   base$knitr$opts_chunk$fig.align <- "center"
+  options(prompt = "R> ", continue = "R+ ")
 
   hook_chunk <- function(x, options) {
     if (output_asis(x, options)) return(x)
     paste0('\\begin{CodeChunk}\n', x, '\\end{CodeChunk}')
   }
   hook_input <- function(x, options) {
+    if (options$prompt && length(x)) {
+      x <- gsub("\\n", paste0("\n", getOption("continue")), x)
+      x <- paste0(getOption("prompt"), x)
+    }
     paste0(c('\\begin{CodeInput}', x, '\\end{CodeInput}', ''),
       collapse = '\n')
   }

--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -35,12 +35,11 @@ jss_article <- function(..., keep_tex = TRUE) {
   base$knitr$opts_chunk$fig.width <- 4.9 # 6.125" * 0.8, as in template
   base$knitr$opts_chunk$fig.height <- 3.675 # 4.9 * 3:4
   base$knitr$opts_chunk$fig.align <- "center"
-  options(prompt = "R> ", continue = "R+ ")
-
   hook_chunk <- function(x, options) {
     if (output_asis(x, options)) return(x)
     paste0('\\begin{CodeChunk}\n', x, '\\end{CodeChunk}')
   }
+  save <- options(prompt = "R> ", continue = "R+ ")
   hook_input <- function(x, options) {
     if (options$prompt && length(x)) {
       x <- gsub("\\n", paste0("\n", getOption("continue")), x)
@@ -52,13 +51,21 @@ jss_article <- function(..., keep_tex = TRUE) {
   hook_output <- function(x, options) {
     paste0('\\begin{CodeOutput}\n', x, '\\end{CodeOutput}\n')
   }
-
+  old_hook <- base$knitr$knit_hooks$document
+  hook_document <- function(x) {
+    options(save)
+    if (is.function(old_hook))
+      old_hook(x)
+    else
+      base::identity(x)
+  }
   base$knitr$knit_hooks$chunk   <- hook_chunk
   base$knitr$knit_hooks$source  <- hook_input
   base$knitr$knit_hooks$output  <- hook_output
   base$knitr$knit_hooks$message <- hook_output
   base$knitr$knit_hooks$warning <- hook_output
   base$knitr$knit_hooks$plot <- knitr::hook_plot_tex
+  base$knitr$knit_hooks$document <- hook_document
 
   base
 }


### PR DESCRIPTION
This fixes the problem that `jss_article` doesn't show the R prompts.  It sets the default prompt to "R> ", with continuation as "R+ ", but allows the document to change these settings.