### PR TITLE
Ensure empty line between environments.

### DIFF
--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -45,11 +45,11 @@ jss_article <- function(..., keep_tex = TRUE) {
       x <- gsub("\\n", paste0("\n", getOption("continue")), x)
       x <- paste0(getOption("prompt"), x)
     }
-    paste0(c('\\begin{CodeInput}', x, '\\end{CodeInput}', ''),
+    paste0(c('\n\\begin{CodeInput}', x, '\\end{CodeInput}', ''),
       collapse = '\n')
   }
   hook_output <- function(x, options) {
-    paste0('\\begin{CodeOutput}\n', x, '\\end{CodeOutput}\n')
+    paste0('\n\\begin{CodeOutput}\n', x, '\\end{CodeOutput}\n')
   }
   old_hook <- base$knitr$knit_hooks$document
   hook_document <- function(x) {


### PR DESCRIPTION
Fixes the problem that pandoc creates a tex file with \end{CodeOutput}\begin{CodeInput} in same line that raises this error with pdflatex: "! FancyVerb Error: Extraneous input `\begin{CodeInput}\end{}' between \end{CodeOutput} and line end".