### PR TITLE
Output file name for RJournal articles: same as input Rmd

### DIFF
--- a/R/rjournal_article.R
+++ b/R/rjournal_article.R
@@ -35,9 +35,11 @@ rjournal_article <- function(...) {
     wrapper_template <- find_resource("rjournal_article", "RJwrapper.tex")
     wrapper_output <- file.path(getwd(), "RJwrapper.tex")
     template_pandoc(wrapper_metadata, wrapper_template, wrapper_output, verbose)
-
     tools::texi2pdf("RJwrapper.tex", clean = clean)
-    "RJwrapper.pdf"
+    #browser()
+    file.rename("RJwrapper.tex",output_file)
+    file.rename("RJwrapper.pdf",gsub(".tex",".pdf",output_file))
+    gsub(".tex",".pdf",output_file)
   }
 
   # Mostly copied from knitr::render_sweave

--- a/R/rjournal_article.R
+++ b/R/rjournal_article.R
@@ -35,10 +35,11 @@ rjournal_article <- function(...) {
     wrapper_template <- find_resource("rjournal_article", "RJwrapper.tex")
     wrapper_output <- file.path(getwd(), "RJwrapper.tex")
     template_pandoc(wrapper_metadata, wrapper_template, wrapper_output, verbose)
+
     tools::texi2pdf("RJwrapper.tex", clean = clean)
-    file.rename("RJwrapper.tex",output_file)
-    file.rename("RJwrapper.pdf",gsub(".tex",".pdf",output_file))
-    gsub(".tex",".pdf",output_file)
+    file.rename("RJwrapper.tex", output_file)
+    file.rename("RJwrapper.pdf", gsub(".tex", ".pdf", output_file))
+    gsub(".tex", ".pdf", output_file)
   }
 
   # Mostly copied from knitr::render_sweave

--- a/R/rjournal_article.R
+++ b/R/rjournal_article.R
@@ -36,7 +36,6 @@ rjournal_article <- function(...) {
     wrapper_output <- file.path(getwd(), "RJwrapper.tex")
     template_pandoc(wrapper_metadata, wrapper_template, wrapper_output, verbose)
     tools::texi2pdf("RJwrapper.tex", clean = clean)
-    #browser()
     file.rename("RJwrapper.tex",output_file)
     file.rename("RJwrapper.pdf",gsub(".tex",".pdf",output_file))
     gsub(".tex",".pdf",output_file)


### PR DESCRIPTION
I was just starting on an RJournal article and noticed that the output file names (.tex and .pdf) were getting changed to RJwrapper and didn't maintain the original file name of the Rmd.  

I added in a few lines to convert to the output RJwrapper.tex and RJwrapper.pdf to the name of the input Rmd.   

Hope you find this helpful!