### PR TITLE
Tables in SiM template

### DIFF
--- a/inst/rmarkdown/templates/sim_article/resources/template.tex
+++ b/inst/rmarkdown/templates/sim_article/resources/template.tex
@@ -3,6 +3,9 @@
 \usepackage[colorlinks,bookmarksopen,bookmarksnumbered,citecolor=red,urlcolor=red]{hyperref}
 \usepackage[numbers, sort&compress]{natbib}
 \def\volumeyear{$year$}
+$if(tablesenv)$
+\usepackage{$tablesenv$}
+$endif$
 
 \begin{document}
 

--- a/inst/rmarkdown/templates/sim_article/resources/template.tex
+++ b/inst/rmarkdown/templates/sim_article/resources/template.tex
@@ -3,9 +3,10 @@
 \usepackage[colorlinks,bookmarksopen,bookmarksnumbered,citecolor=red,urlcolor=red]{hyperref}
 \usepackage[numbers, sort&compress]{natbib}
 \def\volumeyear{$year$}
-$if(tablesenv)$
-\usepackage{$tablesenv$}
-$endif$
+
+$for(header-includes)$
+$header-includes$
+$endfor$
 
 \begin{document}
 

--- a/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
@@ -15,6 +15,7 @@ year: 2017
 abstract: "This paper describes the use of the \LaTeX `simauth.cls` class file for setting papers for Statistics in Medicine using Rmarkdown."
 acknowledgements: "We thank [Stack Overflow](https://stackoverflow.com/) for the invaluable support to our research."
 keywords: Class file; \LaTeX; Statist. Med.; Rmarkdown;
+tablesenv: ctable
 bibliography: bibfile.bib
 output: rticles::sim_article
 ---
@@ -132,6 +133,50 @@ xtable(head(cars), caption = "A table", label = "tab:table")
 ```
 
 Referenced via \ref{tab:table}.
+
+You can also use the YAML option `tablesenv` to define which \LaTeX package for tables to use (`pandoc` uses `longtables` by default, and it is hardcoded). Consequently, just write straight-up \LaTeX code for tables, e.g. using `ctable`:
+
+```
+\ctable[cap = {Short caption},
+        caption = {A long, long, long, long, long caption for this nice, fancy, extremely important table.},
+        label={tab:ctable},]
+        {cc}
+        {
+        \tnote[$\ast$]{Footnote 1}
+        \tnote[$\dagger$]{Other footnote}
+        \tnote[b]{Mistakes are possible.}
+        }{
+        \FL 
+        COL 1\tmark[a] & COL 2\tmark[$\ast$] 
+        \ML
+        6.92\tmark[$\dagger$] & 0.09781 \\
+        6.93\tmark[$\dagger$] & 0.09901 \\
+        97 & 2000
+        \LL
+}
+```
+
+Reference it as usual: \ref{tab:ctable}.
+
+\ctable[cap = {Short caption},
+        caption = {A long, long, long, long, long caption for a table},
+        label={tab:ctable},]
+        {cc}
+        {
+        \tnote[$\ast$]{Footnote 1}
+        \tnote[$\dagger$]{Other footnote}
+        \tnote[b]{Mistakes are possible.}
+        }{
+        \FL 
+        COL 1\tmark[a] & COL 2\tmark[$\ast$] 
+        \ML
+        6.92\tmark[$\dagger$] & 0.09781 \\
+        6.93\tmark[$\dagger$] & 0.09901 \\
+        97 & 2000
+        \LL
+}
+
+Analogously, you can use `longtable`; but why would you do that?
 
 ## Cross-referencing
 

--- a/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
@@ -15,9 +15,12 @@ year: 2017
 abstract: "This paper describes the use of the \LaTeX `simauth.cls` class file for setting papers for Statistics in Medicine using Rmarkdown."
 acknowledgements: "We thank [Stack Overflow](https://stackoverflow.com/) for the invaluable support to our research."
 keywords: Class file; \LaTeX; Statist. Med.; Rmarkdown;
-tablesenv: ctable
+header-includes: 
+- \usepackage{ctable}
 bibliography: bibfile.bib
-output: rticles::sim_article
+output: 
+  rticles::sim_article:
+    keep_tex: TRUE
 ---
 
 # Introduction
@@ -134,7 +137,7 @@ xtable(head(cars), caption = "A table", label = "tab:table")
 
 Referenced via \ref{tab:table}.
 
-You can also use the YAML option `tablesenv` to define which \LaTeX package for tables to use (`pandoc` uses `longtables` by default, and it is hardcoded). Consequently, just write straight-up \LaTeX code for tables, e.g. using `ctable`:
+You can also use the YAML option `header-includes` to includes custom \LaTeX packages for tables (keep in mind that `pandoc` uses `longtables` by default, and it is hardcoded). Consequently, just write straight-up \LaTeX code for tables, e.g. using `ctable`, and reference is as usual (\ref{tab:ctable}).
 
 ```
 \ctable[cap = {Short caption},
@@ -156,8 +159,6 @@ You can also use the YAML option `tablesenv` to define which \LaTeX package for 
 }
 ```
 
-Reference it as usual: \ref{tab:ctable}.
-
 \ctable[cap = {Short caption},
         caption = {A long, long, long, long, long caption for a table},
         label={tab:ctable},]
@@ -175,8 +176,6 @@ Reference it as usual: \ref{tab:ctable}.
         97 & 2000
         \LL
 }
-
-Analogously, you can use `longtable`; but why would you do that?
 
 ## Cross-referencing
 

--- a/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
@@ -15,12 +15,8 @@ year: 2017
 abstract: "This paper describes the use of the \LaTeX `simauth.cls` class file for setting papers for Statistics in Medicine using Rmarkdown."
 acknowledgements: "We thank [Stack Overflow](https://stackoverflow.com/) for the invaluable support to our research."
 keywords: Class file; \LaTeX; Statist. Med.; Rmarkdown;
-header-includes: 
-- \usepackage{ctable}
 bibliography: bibfile.bib
-output: 
-  rticles::sim_article:
-    keep_tex: TRUE
+output: rticles::sim_article
 ---
 
 # Introduction
@@ -137,11 +133,15 @@ xtable(head(cars), caption = "A table", label = "tab:table")
 
 Referenced via \ref{tab:table}.
 
-You can also use the YAML option `header-includes` to includes custom \LaTeX packages for tables (keep in mind that `pandoc` uses `longtables` by default, and it is hardcoded). Consequently, just write straight-up \LaTeX code for tables, e.g. using `ctable`, and reference is as usual (\ref{tab:ctable}).
-
+You can also use the YAML option `header-includes` to includes custom \LaTeX packages for tables (keep in mind that `pandoc` uses `longtables` by default, and it is hardcoded; some things may require including the package `longtable`). E.g., using `ctable`:
+```
+header-includes: 
+- \usepackage{ctable}
+```
+Then, just write straight-up \LaTeX code and reference is as usual (`\ref{tab:ctable}`):
 ```
 \ctable[cap = {Short caption},
-        caption = {A long, long, long, long, long caption for this nice, fancy, extremely important table.},
+        caption = {A long, long, long, long, long caption for this table.},
         label={tab:ctable},]
         {cc}
         {
@@ -158,24 +158,6 @@ You can also use the YAML option `header-includes` to includes custom \LaTeX pac
         \LL
 }
 ```
-
-\ctable[cap = {Short caption},
-        caption = {A long, long, long, long, long caption for a table},
-        label={tab:ctable},]
-        {cc}
-        {
-        \tnote[$\ast$]{Footnote 1}
-        \tnote[$\dagger$]{Other footnote}
-        \tnote[b]{Mistakes are possible.}
-        }{
-        \FL 
-        COL 1\tmark[a] & COL 2\tmark[$\ast$] 
-        \ML
-        6.92\tmark[$\dagger$] & 0.09781 \\
-        6.93\tmark[$\dagger$] & 0.09901 \\
-        97 & 2000
-        \LL
-}
 
 ## Cross-referencing
 


### PR DESCRIPTION
Hi!
I added support for custom tables packages to the Statistics in Medicine template, via adding the `header-includes` option in the YAML header.
Best wishes,

Alessandro