### PR TITLE
header-includes were being included twice in the elsevier template.

### DIFF
--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -147,9 +147,6 @@ $if(lang)$
   \usepackage[$lang$]{babel}
 \fi
 $endif$
-$for(header-includes)$
-$header-includes$
-$endfor$
 % Pandoc toggle for numbering sections (defaults to be off)
 $if(numbersections)$
 $else$


### PR DESCRIPTION
The
```
$for(header-includes)$
$header-includes$
$endfor$
```
construction was present twice in the template for `elsevier_article`. This causes problems when, say, what is being included is a file with macro definitions, since the macros get defined twice, causing an error.