### PR TITLE
Added handling of header-includes to the jss_article template.

### DIFF
--- a/inst/rmarkdown/templates/jss_article/resources/template.tex
+++ b/inst/rmarkdown/templates/jss_article/resources/template.tex
@@ -48,6 +48,11 @@ $for(author)$
 $endfor$
 }
 
+% Pandoc header
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 $preamble$
 
 \begin{document}


### PR DESCRIPTION
It looks like some of the templates support `header-includes`, while others support `preamble`, and a few (including JSS, now) support both.