### PR TITLE
Added explicit longtable option

### DIFF
--- a/R/sim_article.R
+++ b/R/sim_article.R
@@ -1,13 +1,31 @@
 #' Statistics in Medicine format.
 #'
-#' Format for creating submissions to Statistics in Medicine. Adapted from
-#' \href{http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm}{http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm}.
+#' Format for creating submissions to Statistics in Medicine. Based on the official Statistics in Medicine
+#' \href{http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm}{class}.
 #'
 #' @inheritParams rmarkdown::pdf_document
 #' @param ... Additional arguments to \code{rmarkdown::pdf_document}
 #'
 #' @return R Markdown output format to pass to
 #'   \code{\link[rmarkdown:render]{render}}
+#'
+#' @details Possible arguments for the YAML header are:
+#' \itemize{
+#'  \item \code{classoption}:,class options for the Statistics in Medicine class such as \code{doublespace} for double spacing the document
+#'  \item \code{year} and \code{date}: year of the manuscript submission
+#'  \item \code{longtable}: set to \code{true} for including the \code{longtable} package
+#'  \item \code{header-includes}: custom additions to the header, before the \code{\\begin\{document\}} statement
+#'  \item \code{authabbr}: abbreviation of the author for page headers
+#'  \item \code{title}: title of the manuscript
+#'  \item \code{author}: author(s), include as a string with \code{\\affilnum\{\}} statements for defining affiliations
+#'  \item \code{address}: a list of \code{num} and \code{address}, where the former is the equivalent of \code{affilnum} specified in the \code{author} field and the latter is the description of the institution
+#'  \item \code{corraddr}: corresponding address
+#'  \item \code{abstract}: abstract of the manuscript
+#'  \item \code{keywords}: keywords
+#'  \item \code{acknowledgements}: acknowledgements section, to appear at the end of the main body
+#'  \item \code{bibliography}: BibTeX file to include for references
+#'  \item \code{bibliographystyle}: bibliograpy style (\code{wileyj} by default)
+#'  \item \code{include-after}}: for including additional LaTeX code before the \code{\\end\{document\} statement}
 #'
 #' @examples
 #'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The **rticles** package provides a suite of custom [R Markdown](http://rmarkdown
 
 - [IEEE Transaction](http://www.ieee.org/publications_standards/publications/authors/author_templates.html) journal submissions
 
+- [Statistics in Medicine](http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm) journal submissions
+
 Under the hood, LaTeX templates are used to ensure that documents conform precisely to submission standards. At the same time, composition and formatting can be done using lightweight [markdown](http://rmarkdown.rstudio.com/authoring_basics.html) syntax, and R code and its output can be seamlessly included using [knitr](http://yihui.name/knitr/).
 
 Using **rticles** requires the prerequisites described below. You can get most of these automatically by installing the latest release of RStudio (instructions for using **rticles** without RStudio are also provided).

--- a/inst/rmarkdown/templates/sim_article/resources/template.tex
+++ b/inst/rmarkdown/templates/sim_article/resources/template.tex
@@ -4,6 +4,10 @@
 \usepackage[numbers, sort&compress]{natbib}
 \def\volumeyear{$year$}
 
+$if(longtable)$
+\usepackage{longtable}
+$endif$
+
 $for(header-includes)$
 $header-includes$
 $endfor$

--- a/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/sim_article/skeleton/skeleton.Rmd
@@ -77,7 +77,15 @@ Configure the YAML header including the following elements:
 
 * `keywords`: Up to 6 keywords
 
-* `bibliography`: Bibtex `.bib` file
+* `acknowledgements`: Acknowledgements section, at the end of the manuscript
+
+* `bibliography`: BibTeX `.bib` file
+
+* `bibliographystyle`: BibTeX bibliography style, `wileyj` by default
+
+* `classoption`: options of the `simauth` class
+
+* `longtable`: set to `true` to include the `longtable` package, used by default from `pandoc` to convert markdown to \LaTeX code
 
 ## Author information
 
@@ -128,7 +136,8 @@ Analogously, use Rmarkdown to produce tables as usual:
 
 ```{r, results = "asis"}
 library(xtable)
-xtable(head(cars), caption = "A table", label = "tab:table")
+xt <- xtable(head(cars), caption = "A table", label = "tab:table")
+print(xt, comment = FALSE)
 ```
 
 Referenced via \ref{tab:table}.
@@ -158,6 +167,8 @@ Then, just write straight-up \LaTeX code and reference is as usual (`\ref{tab:ct
         \LL
 }
 ```
+
+It is also possible to set the `YAML` option `longtable: true` and use markdown tables (or the `knitr::kable` function): `knitr::kable(head(cars))` produces the same table as the `xtable` example presented before.
 
 ## Cross-referencing
 

--- a/man/sim_article.Rd
+++ b/man/sim_article.Rd
@@ -21,8 +21,27 @@ R Markdown output format to pass to
   \code{\link[rmarkdown:render]{render}}
 }
 \description{
-Format for creating submissions to Statistics in Medicine. Adapted from
-\href{http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm}{http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm}.
+Format for creating submissions to Statistics in Medicine. Based on the official Statistics in Medicine
+\href{http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0258/homepage/la_tex_class_file.htm}{class}.
+}
+\details{
+Possible arguments for the YAML header are:
+\itemize{
+ \item \code{classoption}:,class options for the Statistics in Medicine class such as \code{doublespace} for double spacing the document
+ \item \code{year} and \code{date}: year of the manuscript submission
+ \item \code{longtable}: set to \code{true} for including the \code{longtable} package
+ \item \code{header-includes}: custom additions to the header, before the \code{\\begin\{document\}} statement
+ \item \code{authabbr}: abbreviation of the author for page headers
+ \item \code{title}: title of the manuscript
+ \item \code{author}: author(s), include as a string with \code{\\affilnum\{\}} statements for defining affiliations
+ \item \code{address}: a list of \code{num} and \code{address}, where the former is the equivalent of \code{affilnum} specified in the \code{author} field and the latter is the description of the institution
+ \item \code{corraddr}: corresponding address
+ \item \code{abstract}: abstract of the manuscript
+ \item \code{keywords}: keywords
+ \item \code{acknowledgements}: acknowledgements section, to appear at the end of the main body
+ \item \code{bibliography}: BibTeX file to include for references
+ \item \code{bibliographystyle}: bibliograpy style (\code{wileyj} by default)
+ \item \code{include-after}}: for including additional LaTeX code before the \code{\\end\{document\} statement}
 }
 \examples{
 


### PR DESCRIPTION
I added the explicit option for loading the LaTeX longtable package (see #126). I also expanded the documentation with all the possible YAML options.