### PR TITLE
remove endfloat package

### DIFF
--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -392,7 +392,6 @@ $endif$
 $for(header-includes)$
 $header-includes$
 $endfor$
-\usepackage[nomarkers]{endfloat}
 
 %% END MY ADDITIONS %%
 


### PR DESCRIPTION
`endfloat` package is not in IEEETran. If needed it can be added in the header.