### PR TITLE
prevent extra spaces between Chinese and non-Chinese characters in code blocks

### DIFF
--- a/inst/rmarkdown/templates/ctex/resources/default.latex
+++ b/inst/rmarkdown/templates/ctex/resources/default.latex
@@ -94,12 +94,12 @@ $if(lhs)$
 $endif$
 $if(highlighting-macros)$
 $highlighting-macros$
+\RecustomVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},formatcom=\xeCJKVerbAddon}
 $endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 \VerbatimFootnotes
 $endif$
-\RecustomVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},formatcom=\xeCJKVerbAddon}
 $if(tables)$
 \usepackage{longtable,booktabs}
 $endif$

--- a/inst/rmarkdown/templates/ctex/resources/default.latex
+++ b/inst/rmarkdown/templates/ctex/resources/default.latex
@@ -99,6 +99,7 @@ $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 \VerbatimFootnotes
 $endif$
+\RecustomVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},formatcom=\xeCJKVerbAddon}
 $if(tables)$
 \usepackage{longtable,booktabs}
 $endif$


### PR DESCRIPTION
prevent extra spaces between Chinese and non-Chinese characters in code blocks
the same issue like here https://github.com/yihui/bookdown-chinese/commit/c70ef766b117f3
and here https://stackoverflow.com/q/47990152/559676