### PR TITLE
fix sep in keywords line in Elsevier template

### DIFF
--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -164,7 +164,7 @@ $preamble$
   \begin{abstract}
   $abstract$
   \end{abstract}
-  $if(keywords)$ \begin{keyword} $for(keywords)$$keywords$ \sep $endfor$\end{keyword}$endif$
+  $if(keywords)$ \begin{keyword} $for(keywords)$$keywords$$sep$ $endfor$\end{keyword}$endif$
  \end{frontmatter}
 
 $body$


### PR DESCRIPTION
This small fix removes a trailing comma which occures in the keywords list.