### PR TITLE
Set package encoding to utf-8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,3 +34,4 @@ Imports: utils, rmarkdown, knitr, yaml
 SystemRequirements: GNU make
 RoxygenNote: 6.0.1
 Suggests: testthat, bookdown
+Encoding: UTF-8


### PR DESCRIPTION
Otherwise `document()` fails for me (on `amq_article()`)