### PR TITLE
Add \tightlist macro to ieee_article

### DIFF
--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -393,6 +393,9 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 %% END MY ADDITIONS %%
 
 


### PR DESCRIPTION
Using the ieee_article template from 7708443062fb8c3bd06f9ccda77cbd003d9ff5a5, using an ordered list in the Rmarkdown:

```

1. foo
2. bar

```

results in the following error (from pdflatex) when generating a PDF: 

```
! Undefined control sequence.
l.696 \tightlist
```

Copying the \tightlist macro definition from the template.tex in another format into the ieee_article template.tex resolved the issue (though I'm not sure if there's a more preferable spot in template.tex to put the \tightlist definition).