### PR TITLE
Add header-includes to various TeX templates

### DIFF
--- a/inst/rmarkdown/templates/acm_article/resources/template.tex
+++ b/inst/rmarkdown/templates/acm_article/resources/template.tex
@@ -56,6 +56,9 @@ $for(author)$
 \conferenceinfo{} {}
 \CopyrightYear{}
 \crdata{}
+$for(header-includes)$
+$header-includes$                   
+$endfor$
 
 \begin{document}
 $if(title)$

--- a/inst/rmarkdown/templates/aea_article/resources/template.tex
+++ b/inst/rmarkdown/templates/aea_article/resources/template.tex
@@ -25,6 +25,9 @@
 
 \usepackage{hyperref}
 
+$for(header-includes)$
+$header-includes$
+$endfor$
 \begin{document}
 
 \title{$title$}

--- a/inst/rmarkdown/templates/amq_article/resources/template.tex
+++ b/inst/rmarkdown/templates/amq_article/resources/template.tex
@@ -237,6 +237,10 @@
 
 \everymath{\displaystyle}
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 \begin{document}
 
 %%==========================Éléments propres à l'auteur==============================

--- a/inst/rmarkdown/templates/asa_article/resources/template.tex
+++ b/inst/rmarkdown/templates/asa_article/resources/template.tex
@@ -28,6 +28,10 @@ $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 \begin{document}
 
 

--- a/inst/rmarkdown/templates/mdpi_article/resources/template.tex
+++ b/inst/rmarkdown/templates/mdpi_article/resources/template.tex
@@ -139,6 +139,10 @@ $endif$
 %\setcounter{secnumdepth}{4}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 \begin{document}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Only for the journal Gels: Please place the Experimental Section after the Conclusions

--- a/inst/rmarkdown/templates/rjournal_article/resources/template.tex
+++ b/inst/rmarkdown/templates/rjournal_article/resources/template.tex
@@ -10,6 +10,10 @@ $abstract$
 }
 $endif$
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 $body$
 
 $for(author)$

--- a/inst/rmarkdown/templates/rss_article/resources/template.tex
+++ b/inst/rmarkdown/templates/rss_article/resources/template.tex
@@ -35,6 +35,10 @@ $endif$
 \usepackage[authoryear]{natbib}
 \bibpunct{(}{)}{;}{a}{}{,}
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 \begin{document}
 
 \begin{abstract}

--- a/inst/rmarkdown/templates/springer_article/resources/template.tex
+++ b/inst/rmarkdown/templates/springer_article/resources/template.tex
@@ -34,6 +34,10 @@ $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 \begin{document}
 
 \title{$title$ $if(thanks)$\thanks{$thanks$} $endif$}


### PR DESCRIPTION
See #90. This passes tests on my machine, though I haven't added tests to confirm header-includes are working. I get some warnings about "input string XXX is invalid in this locale".