### PR TITLE
Update template.tex

### DIFF
--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -105,7 +105,7 @@ $endif$
             bookmarks=true,
             pdfauthor={$author-meta$},
             pdftitle={$title-meta$},
-            colorlinks=true,
+            colorlinks=$if(colorlinks)$$colorlinks$$else$true$endif$,
             urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
             linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
             pdfborder={0 0 0}}

--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -105,7 +105,7 @@ $endif$
             bookmarks=true,
             pdfauthor={$author-meta$},
             pdftitle={$title-meta$},
-            colorlinks=$if(colorlinks)$$colorlinks$$else$true$endif$,
+            colorlinks=$if(colorlinks)$true$else$false$endif$,
             urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
             linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
             pdfborder={0 0 0}}


### PR DESCRIPTION
Added option to turn coloring of hyperlinks off. Passing values to colorlinks or urlcolor from yaml does work, but I found that only setting colorlinks=false actually rendered the links (urls as well as refernces to tables and figures) in black color. I have not done this before, so I am not sure if this will do the trick...
