### PR TITLE
IEEETrans authors layout enhancements

### DIFF
--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -335,9 +335,7 @@ $if(natbib)$
 \bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$
-\usepackage{biblatex}
-\bibliographystyle{IEEEtran}
-\bibliography{IEEEabrv}
+\usepackage[backend=bibtex,citestyle=ieee,style=numeric]{biblatex}
 $if(bibliography)$
 $for(bibliography)$
 \addbibresource{$bibliography$}

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -423,50 +423,59 @@ $endfor$
 
 \author{
 $if(affiliation)$
-% %% ---- classic IEEETrans wide author list
-% \IEEEauthorblockN{
-% $for(author)$  %% -- beg for/author ------
-% $author.name$\IEEEauthorrefmark{$author.affiliation$}
-% $sep$,
-% $endfor$ %% -- end for/author ------
-% }
-%
-% $for(affiliation)$ %% -- beg for/affiliation
-% \IEEEauthorblockA{\IEEEauthorrefmark{$affiliation.index$}
-% $if(affiliation.department)$
-% $affiliation.department$\\
-% $endif$
-% $affiliation.name$,
-% $affiliation.location$
-% $if(affiliation.email)$
-% \\ $affiliation.email$
-% $endif$
-% }
-% $endfor$ %% -- end for/affiliation
-% %% ---------------------------------------
-
-%% ---- SEESAR Innovation Days IEEETrans author list
-$for(affiliation)$
+$if(affiliation.wide)$
+%% ---- classic IEEETrans wide author list
 \IEEEauthorblockN{
-$for(affiliation.author)$  %% -- beg for/author
-$affiliation.author.name$$sep$,
-$endfor$ %% -- end for/author
+$for(affiliation.institution)$ %% -- beg for/affiliation.institution ------
+$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author ------
+$affiliation.institution.author.name$\IEEEauthorrefmark{$affiliation.institution.mark$}
+$sep$,
+$endfor$ %% -- end for/affiliation.institution.author ------
+$sep$,
+$endfor$ %% -- end for/affiliation.institution
 }
-\IEEEauthorblockA{$affiliation.name$\\
-$if(affiliation.department)$
-$affiliation.department$\\
+
+$for(affiliation.institution)$ %% -- beg for/affiliation.institution
+\IEEEauthorblockA{\IEEEauthorrefmark{$affiliation.institution.mark$}
+$if(affiliation.institution.department)$
+$affiliation.institution.department$\\
 $endif$
-$affiliation.location$
-$if(affiliation.email)$
-\\$affiliation.email$\\
+$affiliation.institution.name$,
+$affiliation.institution.location$
+$if(affiliation.institution.email)$
+\\ $affiliation.institution.email$
+$endif$
+}
+$endfor$ %% -- end for/affiliation.institution
+%% ---------------------------------------
+$else$ % -- else affiliation.wide
+%% ---- multiple authors columnar affiliations
+$for(affiliation.institution)$
+\IEEEauthorblockN{
+$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
+$affiliation.institution.author.name$$sep$,
+$endfor$ %% -- end for/affiliation.institution.author
+}
+\IEEEauthorblockA{$affiliation.institution.name$\\
+$if(affiliation.institution.department)$
+$affiliation.institution.department$\\
+$endif$
+$affiliation.institution.location$
+$if(affiliation.institution.email)$
+\\$affiliation.institution.email$
+$else$
+$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
+$if(affiliation.institution.author.email)$
+\\$affiliation.institution.author.email$
+$endif$
+$endfor$ %% -- end for/affiliation.institution.author
 $endif$
 }
 $sep$\and
-$endfor$ %% -- end for/affiliation
+$endfor$ %% -- end for/affiliation.institution
 %% ---------------------------------------
-
-
-$else$
+$endif$ % -- end if/affiliation.wide
+$else$ % -- else/affiliation
 
 %% ---- classic IEEETrans max 3 author list
 $for(author)$
@@ -480,7 +489,7 @@ $author.email$
 }
 $sep$\and
 $endfor$
-$endif$
+$endif$ % -- end if/affiliation
 %% ----------------------------------------
 
 }

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -337,9 +337,11 @@ $endif$
 $if(biblatex)$
 \usepackage{biblatex}
 \bibliographystyle{IEEEtran}
-\bibliography{IEEEabrv,mybibfile}
-$if(biblio-files)$
-\bibliography{$biblio-files$}
+\bibliography{IEEEabrv}
+$if(bibliography)$
+$for(bibliography)$
+\addbibresource{$bibliography$}
+$endfor$
 $endif$
 $endif$
 

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -422,6 +422,53 @@ $endfor$
 % affiliations
 
 \author{
+$if(affiliation)$
+% %% ---- classic IEEETrans wide author list
+% \IEEEauthorblockN{
+% $for(author)$  %% -- beg for/author ------
+% $author.name$\IEEEauthorrefmark{$author.affiliation$}
+% $sep$,
+% $endfor$ %% -- end for/author ------
+% }
+%
+% $for(affiliation)$ %% -- beg for/affiliation
+% \IEEEauthorblockA{\IEEEauthorrefmark{$affiliation.index$}
+% $if(affiliation.department)$
+% $affiliation.department$\\
+% $endif$
+% $affiliation.name$,
+% $affiliation.location$
+% $if(affiliation.email)$
+% \\ $affiliation.email$
+% $endif$
+% }
+% $endfor$ %% -- end for/affiliation
+% %% ---------------------------------------
+
+%% ---- SEESAR Innovation Days IEEETrans author list
+$for(affiliation)$
+\IEEEauthorblockN{
+$for(affiliation.author)$  %% -- beg for/author
+$affiliation.author.name$$sep$,
+$endfor$ %% -- end for/author
+}
+\IEEEauthorblockA{$affiliation.name$\\
+$if(affiliation.department)$
+$affiliation.department$\\
+$endif$
+$affiliation.location$
+$if(affiliation.email)$
+\\$affiliation.email$\\
+$endif$
+}
+$sep$\and
+$endfor$ %% -- end for/affiliation
+%% ---------------------------------------
+
+
+$else$
+
+%% ---- classic IEEETrans max 3 author list
 $for(author)$
 \IEEEauthorblockN{$author.name$}
 \IEEEauthorblockA{$author.affiliation$\\
@@ -433,6 +480,9 @@ $author.email$
 }
 $sep$\and
 $endfor$
+$endif$
+%% ----------------------------------------
+
 }
 
 % conference papers do not typically use \thanks and this command

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -423,14 +423,15 @@ $endfor$
 
 \author{
 $if(affiliation)$
+
+%% ---- classic IEEETrans wide authors' list ----------------
 $if(affiliation.wide)$
-%% ---- classic IEEETrans wide author list
 \IEEEauthorblockN{
-$for(affiliation.institution)$ %% -- beg for/affiliation.institution ------
-$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author ------
+$for(affiliation.institution)$ %% -- beg for/affiliation.institution
+$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
 $affiliation.institution.author.name$\IEEEauthorrefmark{$affiliation.institution.mark$}
 $sep$,
-$endfor$ %% -- end for/affiliation.institution.author ------
+$endfor$ %% -- end for/affiliation.institution.author
 $sep$,
 $endfor$ %% -- end for/affiliation.institution
 }
@@ -447,9 +448,13 @@ $if(affiliation.institution.email)$
 $endif$
 }
 $endfor$ %% -- end for/affiliation.institution
-%% ---------------------------------------
-$else$ % -- else affiliation.wide
-%% ---- multiple authors columnar affiliations
+$endif$ % -- end affiliation.wide
+%% ----------------------------------------------------------
+
+
+
+%% ---- classic IEEETrans one column per institution --------
+$if(affiliation.institution-columnar)$ %% -- beg if/affiliation.institution-columnar
 $for(affiliation.institution)$
 \IEEEauthorblockN{
 $for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
@@ -473,25 +478,43 @@ $endif$
 }
 $sep$\and
 $endfor$ %% -- end for/affiliation.institution
-%% ---------------------------------------
-$endif$ % -- end if/affiliation.wide
-$else$ % -- else/affiliation
+$endif$ %% -- end if/affiliation.institution-columnar
+%% ----------------------------------------------------------
 
-%% ---- classic IEEETrans max 3 author list
-$for(author)$
-\IEEEauthorblockN{$author.name$}
-\IEEEauthorblockA{$author.affiliation$\\
-$if(author.department)$
-$author.department$\\
+
+
+
+
+%% ---- one column per author, classic/default IEEETrans ----
+$if(affiliation.author-columnar)$ % -- beg affiliation.author-columnar
+$for(affiliation.institution)$
+$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
+\IEEEauthorblockN{
+$affiliation.institution.author.name$
+}
+\IEEEauthorblockA{$affiliation.institution.name$\\
+$if(affiliation.institution.department)$
+$affiliation.institution.department$\\
 $endif$
-$author.location$\\
-$author.email$
+$affiliation.institution.location$
+$if(affiliation.institution.email)$
+\\$affiliation.institution.email$
+$else$
+$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
+$if(affiliation.institution.author.email)$
+\\$affiliation.institution.author.email$
+$endif$
+$endfor$ %% -- end for/affiliation.institution.author
+$endif$
 }
 $sep$\and
-$endfor$
-$endif$ % -- end if/affiliation
-%% ----------------------------------------
+$endfor$ %% -- end for/affiliation.institution.author
+$sep$\and
+$endfor$ %% -- end for/affiliation.institution
+$endif$ %% -- end if/affiliation.institution-columnar
+%% ----------------------------------------------------------
 
+$endif$
 }
 
 % conference papers do not typically use \thanks and this command

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -425,7 +425,9 @@ $endfor$
 $for(author)$
 \IEEEauthorblockN{$author.name$}
 \IEEEauthorblockA{$author.affiliation$\\
+$if(author.department)$
 $author.department$\\
+$endif$
 $author.location$\\
 $author.email$
 }

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -1,31 +1,17 @@
 ---
 title: Bare Demo of IEEEtran.cls for IEEE Conferences
-##### up-to-3 authors
-# author:
-#   - name: Michael Shell
-#     affiliation: Georgia Institute of Technology
-#     department: Computer Engineering
-#     location: Atlanta, Georgia 30332--0250
-#     email: ieetran@michaelshell.org
-#   - name: Daniel Emaasit
-#     affiliation: University of Nevada   
-#     department: Civil Engineering
-#     location: Las Vegas, Nevada 89119
-#     email: daniel.emaasit@gmail.com
-#   - name: Alice Wonderland
-#     affiliation: Another University
-#     department: Your Department
-#     location: City, State Zip
-#     email: alice@host.com    
-##### 1) more-than-3 authors wide author/affiliation fields
 ##### 2) multiple authors columnar affiliations (omit wide: true)
 affiliation:
-  # wide: true
+  ## use one only of the following (default: author-columnar)
+  author-columnar: true         ## one column per author
+  # institution-columnar: true  ## one column per institution (multiple autors eventually)
+  # wide: true                  ## one column wide author/affiliation fields
+
   institution:
     - name: Georgia Institute of Technology
       department: School of Electrical and Computer Engineering
       location: Atlanta, Georgia 30332--0250
-      other: "Email: see http://www.michaelshell.org/contact.html"
+      email: ece@datech.edu
       mark: 1
       author:
         - name: Michael Shell
@@ -51,6 +37,7 @@ affiliation:
           email: roy@replicant.offworld
 abstract: |
   The abstract goes here.
+  On multiple lines eventually.
 
 bibliography: mybibfile.bib
 output: rticles::ieee_article

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -1,8 +1,7 @@
 ---
 title: Bare Demo of IEEEtran.cls for IEEE Conferences
-##### 2) multiple authors columnar affiliations (omit wide: true)
 affiliation:
-  ## use one only of the following (default: author-columnar)
+  ## use one only of the following
   author-columnar: true         ## one column per author
   # institution-columnar: true  ## one column per institution (multiple autors eventually)
   # wide: true                  ## one column wide author/affiliation fields

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -2,8 +2,8 @@
 title: Bare Demo of IEEEtran.cls for IEEE Conferences
 affiliation:
   ## use one only of the following
-  author-columnar: true         ## one column per author
-  # institution-columnar: true  ## one column per institution (multiple autors eventually)
+  # author-columnar: true         ## one column per author
+  institution-columnar: true  ## one column per institution (multiple autors eventually)
   # wide: true                  ## one column wide author/affiliation fields
 
   institution:
@@ -27,7 +27,7 @@ affiliation:
       author:
         - name: Montgomery Scott
     - name: Tyrell Inc.
-      location: 123 Replicant Street, Los Angeles, California 90210--4321
+      location: 123 Replicant Street, Los Angeles, USA 90210--4321
       mark: 4
       author:
         - name: Eldon Tyrell

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -1,21 +1,54 @@
 ---
 title: Bare Demo of IEEEtran.cls for IEEE Conferences
-author:
-  - name: Michael Shell
-    affiliation: Georgia Institute of Technology
-    department: Computer Engineering
-    location: Atlanta, Georgia 30332--0250
-    email: ieetran@michaelshell.org
-  - name: Daniel Emaasit
-    affiliation: University of Nevada   
-    department: Civil Engineering
-    location: Las Vegas, Nevada 89119
-    email: daniel.emaasit@gmail.com
-  - name: Alice Wonderland
-    affiliation: Another University
-    department: Your Department
-    location: City, State Zip
-    email: alice@host.com    
+##### up-to-3 authors
+# author:
+#   - name: Michael Shell
+#     affiliation: Georgia Institute of Technology
+#     department: Computer Engineering
+#     location: Atlanta, Georgia 30332--0250
+#     email: ieetran@michaelshell.org
+#   - name: Daniel Emaasit
+#     affiliation: University of Nevada   
+#     department: Civil Engineering
+#     location: Las Vegas, Nevada 89119
+#     email: daniel.emaasit@gmail.com
+#   - name: Alice Wonderland
+#     affiliation: Another University
+#     department: Your Department
+#     location: City, State Zip
+#     email: alice@host.com    
+##### 1) more-than-3 authors wide author/affiliation fields
+##### 2) multiple authors columnar affiliations (omit wide: true)
+affiliation:
+  # wide: true
+  institution:
+    - name: Georgia Institute of Technology
+      department: School of Electrical and Computer Engineering
+      location: Atlanta, Georgia 30332--0250
+      other: "Email: see http://www.michaelshell.org/contact.html"
+      mark: 1
+      author:
+        - name: Michael Shell
+    - name: Twentieth Century Fox
+      location: Springfield, USA
+      mark: 2
+      author:
+        - name: Homer Simpson
+          email: homer@thesimpsons.com
+    - name: Starfleet Academy
+      location: San Francisco, California 96678-2391
+      other: "Telephone: (800) 555--1212, Fax: (888) 555--1212"
+      mark: 3
+      author:
+        - name: Montgomery Scott
+    - name: Tyrell Inc.
+      location: 123 Replicant Street, Los Angeles, California 90210--4321
+      mark: 4
+      author:
+        - name: Eldon Tyrell
+          email: eldon@starfleet-academy.star
+        - name: Roy Batty
+          email: roy@replicant.offworld
 abstract: |
   The abstract goes here.
 


### PR DESCRIPTION
I am writing an article where some authors have no `department` which would result in a blank line:

![with-blank-line](https://user-images.githubusercontent.com/891692/44463992-c5ef7d00-a619-11e8-8283-97d43005fae9.PNG)

This little  proposal make it possible to avoid the (ugly) blank line:

![no-blank-line](https://user-images.githubusercontent.com/891692/44464018-d7388980-a619-11e8-8f1a-e3d1364114f6.PNG)


