### PR TITLE
Enable setting classoption in RSS article type

### DIFF
--- a/inst/rmarkdown/templates/rss_article/resources/template.tex
+++ b/inst/rmarkdown/templates/rss_article/resources/template.tex
@@ -1,5 +1,5 @@
 
-\documentclass{statsoc}
+\documentclass$if(classoption)$[$classoption$]$endif${statsoc}
 \usepackage{graphicx}
 \usepackage{listings}
 \usepackage{color}


### PR DESCRIPTION
Loosely following the way this seems to work in the JSS articles, I have added an optional `[classoption]` element that can be triggered by using `classoption:` in an Rmd file's YAML header.
