### PR TITLE
fix pandoc --latex-engine arg

### DIFF
--- a/R/rsos_article.R
+++ b/R/rsos_article.R
@@ -27,7 +27,7 @@ rsos_article <- function(
   )
   args <- c(
     "--template", template,
-    "--latex-engine", "xelatex",
+    "--pdf-engine", "xelatex",
     pandoc_variable_arg("documentclass", "article"),
     pandoc_args,
     "--natbib",


### PR DESCRIPTION
bugfix: replace `--latex-engine` by `--pdf-engine` for the RSOS article