### PR TITLE
Promote new, preferred DOI resolver

### DIFF
--- a/inst/rmarkdown/templates/acm_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/acm_article/skeleton/skeleton.Rmd
@@ -51,7 +51,7 @@ references:
     given: Martin
   container-title: Nature Materials
   volume: 11
-  URL: 'http://dx.doi.org/10.1038/nmat3283'
+  URL: 'https://doi.org/10.1038/nmat3283'
   DOI: 10.1038/nmat3283
   issue: 4
   publisher: Nature Publishing Group


### PR DESCRIPTION
The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the demo  link.

PS: Since this is similar to a typo fix, I didn't consider the PR template checklist applicable.