### PR TITLE
tiny fix: swapped institution department and name in institution-columnar

### DIFF
--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -461,10 +461,10 @@ $for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.aut
 $affiliation.institution.author.name$$sep$,
 $endfor$ %% -- end for/affiliation.institution.author
 }
-\IEEEauthorblockA{$affiliation.institution.name$\\
-$if(affiliation.institution.department)$
+\IEEEauthorblockA{$if(affiliation.institution.department)$
 $affiliation.institution.department$\\
 $endif$
+$affiliation.institution.name$\\
 $affiliation.institution.location$
 $if(affiliation.institution.email)$
 \\$affiliation.institution.email$


### PR DESCRIPTION
Fixed a tiny issue with institution columnar mode: institution deprtment and institution name are now in the correct order
