### PR TITLE
make ieee_article work with base_format

### DIFF
--- a/R/ieee_article.R
+++ b/R/ieee_article.R
@@ -47,19 +47,20 @@
 #' \url{http://mirrors.rit.edu/CTAN/macros/latex/contrib/IEEEtran/IEEEtran_HOWTO.pdf}
 #' @export
 ieee_article <- function(...,
-                         draftmode        = c("final", "draft", "draftcls",
-                                              "draftclsnofoot"),
-                         hyphenfixes      = "op-tical net-works semi-conduc-tor",
-                         IEEEspecialpaper = "",
-                         with_ifpdf       = FALSE,
-                         with_cite        = FALSE,
-                         with_amsmath     = FALSE,
-                         with_algorithmic = FALSE,
-                         with_subfig      = FALSE,
-                         with_array       = FALSE,
-                         with_dblfloatfix = FALSE,
-                         keep_tex         = TRUE,
-                         md_extensions    = c("-autolink_bare_uris")) {
+  base_format = rmarkdown::pdf_document,
+  draftmode        = c("final", "draft", "draftcls",
+                      "draftclsnofoot"),
+  hyphenfixes      = "op-tical net-works semi-conduc-tor",
+  IEEEspecialpaper = "",
+  with_ifpdf       = FALSE,
+  with_cite        = FALSE,
+  with_amsmath     = FALSE,
+  with_algorithmic = FALSE,
+  with_subfig      = FALSE,
+  with_array       = FALSE,
+  with_dblfloatfix = FALSE,
+  keep_tex         = TRUE,
+  md_extensions    = c("-autolink_bare_uris")) {
 
   args <- c()
 
@@ -93,10 +94,14 @@ ieee_article <- function(...,
 
   # Convert to pandoc arguments
   pandoc_arg_list <- mapply(pandoc_arg_variable, names(args), args)
-
-  inherit_pdf_document(...,
-                       pandoc_args = pandoc_arg_list,
-                       template = find_resource("ieee_article", "template.tex"),
-                       keep_tex = keep_tex,
-                       md_extensions = md_extensions)
+  if (is.character(base_format)) {
+    FMT <- eval(parse(text = base_format))
+  } else {
+    FMT <- match.fun(base_format)
+  }
+  FMT(...,
+    pandoc_args = pandoc_arg_list,
+    template = find_resource("ieee_article", "template.tex"),
+    keep_tex = keep_tex,
+    md_extensions = md_extensions)
 }

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -461,10 +461,10 @@ $for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.aut
 $affiliation.institution.author.name$$sep$,
 $endfor$ %% -- end for/affiliation.institution.author
 }
-\IEEEauthorblockA{$affiliation.institution.name$\\
-$if(affiliation.institution.department)$
+\IEEEauthorblockA{$if(affiliation.institution.department)$
 $affiliation.institution.department$\\
 $endif$
+$affiliation.institution.name$\\
 $affiliation.institution.location$
 $if(affiliation.institution.email)$
 \\$affiliation.institution.email$

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -39,7 +39,8 @@ abstract: |
   On multiple lines eventually.
 
 bibliography: mybibfile.bib
-output: rticles::ieee_article
+  rticles::ieee_article:
+    base_format: rmarkdown::pdf_document # bookdown::pdf_document2 # for using \@ref()
 ---
 
 Introduction

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -39,6 +39,7 @@ abstract: |
   On multiple lines eventually.
 
 bibliography: mybibfile.bib
+output:
   rticles::ieee_article:
     base_format: rmarkdown::pdf_document # bookdown::pdf_document2 # for using \@ref()
 ---


### PR DESCRIPTION
the bits about `base_format` were not working.
I adapted the code from recent article template submission (Copernicus) to fix and have it working with:

```r
output:
  rticles::ieee_article:
    base_format: rmarkdown::pdf_document # bookdown::pdf_document2 # for using \@ref()

```