### PR TITLE
Adds 100 character warning to AGU article

### DIFF
--- a/inst/rmarkdown/templates/agu_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/agu_article/skeleton/skeleton.Rmd
@@ -68,7 +68,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r keypoints_check,  results='asis', eval = TRUE}
+```{r keypoints_check, echo=FALSE, results='asis', eval = TRUE}
 # This chunk adds a warning if any keypoint is longer than 100 characters. 
 # To disable it, you can remove it or set eval to FALSE.
 if (any(nchar(rmarkdown::metadata$keypoints) > 100)) {

--- a/inst/rmarkdown/templates/agu_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/agu_article/skeleton/skeleton.Rmd
@@ -41,8 +41,8 @@ corresponding_author:
     email: groupleader@fancy.university.com
 keypoints:  
   - "List up to three key points (at least one is required)"
-  - "Key Points summarize the main points and conclusions of the article"
-  - "Each must be 100 characters or less with no special characters or punctuation"
+  - "Key Points summarize the main points and conclusions of the article sdfasdfadfasdfasdf adsf asdf asdf ad fasd fadf adfs "
+  - "Each must be 100 characters or less with no special characters or punctuation asddfjhsdlkh adsliufyh alkj asdufk haldkufjh adslfh adsjkf h"
 abstract: |
   A good abstract will begin with a short description of the problem
   being addressed, briefly describe the new data or analyses, then
@@ -66,7 +66,16 @@ knitr::opts_chunk$set(
   out.extra = "",   # To force the use of figure enviroment
   fig.cap = "Please caption every figure"
 )
+```
 
+```{r keypoints_check,  results='asis', eval = TRUE}
+# This chunk adds a warning if any keypoint is longer than 100 characters. 
+# To disable it, you can remove it or set eval to FALSE.
+if (any(nchar(rmarkdown::metadata$keypoints) > 100)) {
+  cat("\\textcolor{red}{\\textbf{Warning}: keypoint(s)", 
+      knitr::combine_words(which(nchar(rmarkdown::metadata$keypoints) > 100)), 
+      "longer than 100 characters.}")
+}
 ```
 
 Suggested section heads

--- a/inst/rmarkdown/templates/agu_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/agu_article/skeleton/skeleton.Rmd
@@ -41,8 +41,8 @@ corresponding_author:
     email: groupleader@fancy.university.com
 keypoints:  
   - "List up to three key points (at least one is required)"
-  - "Key Points summarize the main points and conclusions of the article sdfasdfadfasdfasdf adsf asdf asdf ad fasd fadf adfs "
-  - "Each must be 100 characters or less with no special characters or punctuation asddfjhsdlkh adsliufyh alkj asdufk haldkufjh adslfh adsjkf h"
+  - "Key Points summarize the main points and conclusions of the article"
+  - "Each must be 100 characters or less with no special characters or punctuation"
 abstract: |
   A good abstract will begin with a short description of the problem
   being addressed, briefly describe the new data or analyses, then


### PR DESCRIPTION
I'm trying to automate checking if keywords are less than 100 characters. Do you think this approach is ok? If it detects that some keypoints have more than 100 characters, it prints a red warning in the document:

![image](https://user-images.githubusercontent.com/8617595/54437721-0298d800-4714-11e9-95ce-4f839659e301.png)

I didn't want to make it an error because in I would think that during the drafting process it's common to have a long keypoint that you will shorten later. Throwing a `warning()` is not useful because it gets lost in the sea of knitr messages. I wanted to add the warning at the end of each keyword, but `rmarkdown::metadata$keywords <- things` throws an error. This is the next best thing I came up with. 