### PR TITLE
Royal Statistical Society, not Royal Soc of Stats

### DIFF
--- a/inst/rmarkdown/templates/rss_article/template.yaml
+++ b/inst/rmarkdown/templates/rss_article/template.yaml
@@ -1,4 +1,4 @@
-name: Royal Society of Statistics
+name: Royal Statistical Society
 description: >
  Template for creating an article for submission to RSS
 create_dir: true


### PR DESCRIPTION
A simple error in the name of the template. The RSS is not the Royal Society of Statistics. It is the Royal Statistical Society.