### PR TITLE
edited elsevier_article to use with natbib

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 rticles 0.8
 ---------------------------------------------------------------------
 
-- Added the Taylor & Francis journal template (@dleutnant, #218)
+- Added the Taylor & Francis journal template (@dleutnant, #218).
+
+- The top-level option `biblio-files` in the YAML frontmatter was changed to `bibliography` in the `elsevier_article()` template (@JohannesFriedrich, #222).
 
 rticles 0.7
 ---------------------------------------------------------------------
@@ -21,8 +23,6 @@ rticles 0.7
 - For output formats `acm_article()`, `acs_article()`, `ams_article()`, `mnras_article()`, the csl file should be specified as a top-level option in the YAML header of the document (this has been done in the R Markdown templates). It is no longer specified automatically by the output format functions.
 
 - The function `ctex_template()` was removed. If you need to use a custom LaTeX template for the `ctex` output format, just use the `template` option under `ctex`.
-
-- The template for `elsevier_article()` was changed in that way that the argument `bibliography` is taken into account.
 
 rticles 0.6
 ---------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ rticles 0.7
 
 - The function `ctex_template()` was removed. If you need to use a custom LaTeX template for the `ctex` output format, just use the `template` option under `ctex`.
 
+- The template for `elsevier_article()` was changed in that way that the argument `bibliography` is taken into account.
+
 rticles 0.6
 ---------------------------------------------------------------------
 

--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -14,7 +14,6 @@ $endif$
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
-\bibliographystyle{elsarticle-harv}
 \biboptions{sort&compress} % For natbib
 \usepackage{graphicx}
 \usepackage{booktabs} % book-quality tables
@@ -60,12 +59,8 @@ $endif$
 $if(natbib)$
 \usepackage{natbib}
 \bibliographystyle{plainnat}
-$endif$
-$if(biblatex)$
-\usepackage{biblatex}
-$if(biblio-files)$
-\bibliography{$biblio-files$}
-$endif$
+$else$
+\bibliographystyle{elsarticle-harv}
 $endif$
 $if(listings)$
 \usepackage{listings}
@@ -170,7 +165,7 @@ $preamble$
 $body$
 
 $if(natbib)$
-$if(biblio-files)$
+$if(bibliography)$
 $if(biblio-title)$
 $if(book-class)$
 \renewcommand\bibname{$biblio-title$}
@@ -178,14 +173,11 @@ $else$
 \renewcommand\refname{$biblio-title$}
 $endif$
 $endif$
-\bibliography{$biblio-files$}
+\bibliography{$bibliography$}
 
 $endif$
 $endif$
-$if(biblatex)$
-\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
 
-$endif$
 $for(include-after)$
 $include-after$
 


### PR DESCRIPTION
The option `citation_package: natbib` in the elsevier_article was not possible because the template initialized two bibliographystyles. In addition to that the parameter `bibliography` was not recognized because it was names `biblio-files` in the template.
Furthermore I removed the biblatex commands, because in the elsevier_article class no biblatex support is given and will always give an error.
The only restriction is to name the bibliography file *without* the extension *.bib due to the construction of natbib.