### PR TITLE
add unambiguous flag for Copernicus template detection

### DIFF
--- a/inst/rmarkdown/templates/copernicus_article/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus_article/resources/template.tex
@@ -5,6 +5,7 @@
 %% For further assistance please contact Copernicus Publications at: production@copernicus.org
 %% https://publications.copernicus.org/for_authors/manuscript_preparation.html
 
+%% copernicus_rticles_template (flag for rticles template detection - do not remove!)
 
 %% Please use the following documentclass and journal abbreviations for discussion papers and final revised papers.
 


### PR DESCRIPTION
After the first authors started using the template, I discussed "detecting" submissions based on rticles on the side of the publisher. They would be interested to learn how many authors use the template and have added the flag added by this PR to their publication system to be automatically detected.

No rush, but would be great if this could be included in the next release.