### PR TITLE
ieee_article: Fix lack of propagation of arguments to base formats.

### DIFF
--- a/R/ieee_article.R
+++ b/R/ieee_article.R
@@ -36,7 +36,7 @@
 #' \url{http://mirrors.rit.edu/CTAN/macros/latex/contrib/IEEEtran/IEEEtran_HOWTO.pdf}
 #' @export
 ieee_article <- function(
-  ..., draftmode   = c("final", "draft", "draftcls", "draftclsnofoot"),
+  draftmode   = c("final", "draft", "draftcls", "draftclsnofoot"),
   hyphenfixes      = "op-tical net-works semi-conduc-tor",
   IEEEspecialpaper = "",
   with_ifpdf       = FALSE,
@@ -48,7 +48,8 @@ ieee_article <- function(
   with_dblfloatfix = FALSE,
   keep_tex         = TRUE,
   pandoc_args = NULL,
-  md_extensions    = c("-autolink_bare_uris")
+  md_extensions    = c("-autolink_bare_uris"),
+  ...
 ) {
 
   args <- c()
@@ -83,6 +84,7 @@ ieee_article <- function(
 
   pdf_document_format(
     "ieee_article", pandoc_args = c(pandoc_arg_list, pandoc_args),
-    keep_tex = keep_tex, md_extensions = md_extensions
+    keep_tex = keep_tex, md_extensions = md_extensions,
+    ...
   )
 }

--- a/man/ieee_article.Rd
+++ b/man/ieee_article.Rd
@@ -4,17 +4,15 @@
 \alias{ieee_article}
 \title{IEEE Transactions journal format.}
 \usage{
-ieee_article(..., draftmode = c("final", "draft", "draftcls",
+ieee_article(draftmode = c("final", "draft", "draftcls",
   "draftclsnofoot"), hyphenfixes = "op-tical net-works semi-conduc-tor",
   IEEEspecialpaper = "", with_ifpdf = FALSE, with_cite = FALSE,
   with_amsmath = FALSE, with_algorithmic = FALSE,
   with_subfig = FALSE, with_array = FALSE, with_dblfloatfix = FALSE,
   keep_tex = TRUE, pandoc_args = NULL,
-  md_extensions = c("-autolink_bare_uris"))
+  md_extensions = c("-autolink_bare_uris"), ...)
 }
 \arguments{
-\item{...}{Additional arguments to \code{rmarkdown::pdf_document}}
-
 \item{draftmode}{Specify the draft mode to control spacing and whether images
 should be rendered. Valid options are: \code{"final"} (default), \code{"draft"},
 \code{"draftcls"}, or \code{"draftclsnofoot"}.}
@@ -53,6 +51,8 @@ off (\code{FALSE}) the \code{dblfloatfix} LaTeX package.}
 \item{md_extensions}{Markdown extensions to be added or removed from the
 default definition or R Markdown. See the \code{\link{rmarkdown_format}} for
 additional details.}
+
+\item{...}{Additional arguments to \code{rmarkdown::pdf_document}}
 }
 \description{
 Format for creating submissions to IEEE Transaction journals. Adapted from


### PR DESCRIPTION
Fix lack of propagation of arguments to base formats.
A symptom of the issue was the failure to include extra settings via `in_header` when using something like:
```
output:
  bookdown::pdf_book:
    base_format: rticles::ieee_article
```