### PR TITLE
Added shared footnotes to elsevier_article()

### DIFF
--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -147,12 +147,14 @@ $preamble$
 
   \title{$title$}
   $for(author)$
-  \author[$author.affiliation$]{$author.name$$if(author.footnote)$\corref{c1}$endif$}
+  \author[$author.affiliation$]{$author.name$$if(author.footnote)$\corref{$author.footnote$}$endif$}
   $if(author.email)$ \ead{$author.email$} $endif$
-  $if(author.footnote)$ \cortext[c1]{$author.footnote$}$endif$
   $endfor$
   $for(address)$
   \address[$address.code$]{$address.address$}
+  $endfor$
+  $for(fn)$
+  \cortext[$fn.code$]{$fn.text$}
   $endfor$
 
   \begin{abstract}

--- a/inst/rmarkdown/templates/elsevier_article/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier_article/resources/template.tex
@@ -153,8 +153,8 @@ $preamble$
   $for(address)$
   \address[$address.code$]{$address.address$}
   $endfor$
-  $for(fn)$
-  \cortext[$fn.code$]{$fn.text$}
+  $for(footnote)$
+  \cortext[$footnote.code$]{$footnote.text$}
   $endfor$
 
   \begin{abstract}

--- a/inst/rmarkdown/templates/elsevier_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/elsevier_article/skeleton/skeleton.Rmd
@@ -21,7 +21,7 @@ address:
     address: Department, Street, City, State, Zip
   - code: Another University
     address: Department, Street, City, State, Zip
-fn:
+footnote:
   - code: 1
     text: "Corresponding Author"
   - code: 2

--- a/inst/rmarkdown/templates/elsevier_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/elsevier_article/skeleton/skeleton.Rmd
@@ -4,15 +4,28 @@ author:
   - name: Alice Anonymous
     email: alice@example.com
     affiliation: Some Institute of Technology
-    footnote: Corresponding Author
+    footnote: 1
   - name: Bob Security
     email: bob@example.com
     affiliation: Another University
+  - name: Cat Memes
+    email: cat@example.com
+    affiliation: Another University
+    footnote: 2
+  - name: Derek Zoolander
+    email: derek@example.com
+    affiliation: Some Institute of Technology
+    footnote: 2
 address:
   - code: Some Institute of Technology
     address: Department, Street, City, State, Zip
   - code: Another University
     address: Department, Street, City, State, Zip
+fn:
+  - code: 1
+    text: "Corresponding Author"
+  - code: 2
+    text: "Equal contribution"
 abstract: |
   This is the abstract.
 


### PR DESCRIPTION
Updated the template for elsevier_article to allow for two authors to share the same footnote (e.g. "these authors made equal contributions") and updated the corresponding skeleton to demonstrate how to use a shared footnote. To do this, I mimicked the style of shared affiliations. (This is my first pull request to an RStudio repo. Any feedback you have for me would be much appreciated!)