### PR TITLE
Add support for bibliography styles on springer template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rticles 0.13
 
 - Fixed header includes for `rjournal_article()` (thanks, @agila5 #257, @rcannood #261).
 
+- Add support for bibliography styles on the Springer template (thanks, @swhaat, #262).
+
 rticles 0.12
 ---------------------------------------------------------------------
 

--- a/inst/rmarkdown/templates/springer_article/resources/template.tex
+++ b/inst/rmarkdown/templates/springer_article/resources/template.tex
@@ -111,7 +111,7 @@ $endif$
 
 $body$
 
-\bibliographystyle{spbasic}
+\bibliographystyle{$if(bibstyle)$ $bibstyle$ $else$spbasic$endif$}
 \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 
 \end{document}

--- a/inst/rmarkdown/templates/springer_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/springer_article/skeleton/skeleton.Rmd
@@ -28,12 +28,14 @@ keywords:
     
 MSC:
 - MSC code 1
-- MSC code 2    
+- MSC code 2
 
 abstract: |
   The text of your abstract.  150 -- 250 words.
 
 bibliography: bibliography.bib
+bibstyle: spphys
+# bibstyle options spbasic(default), spphys, spmpsci
 output: rticles::springer_article
 ---
 


### PR DESCRIPTION
As springer latex offers support for 3 kind of bibliography styles, it would be nice to have the possibility to modify it with a variable *bibstyle*.
If no variable is defined, the default goes to *spbasic*.
