### PR TITLE
Sorting bibliography

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Authors@R: c(
   person("Zhian N.", "Kamvar", role = c("aut", "cph"), email = "zkamvar@gmail.com", comment = c(ORCID = "0000-0003-1458-7108")),
   person("Noam", "Ross", role = c("aut", "cph"), email = "noam.ross@gmail.com", comment = c(ORCID = "0000-0002-2136-0000")),
   person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),
-  person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com", comment = c(github="DunLug"))
+  person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com")
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Authors@R: c(
   person("John", "Muschelli", role = c("aut", "cph"), email = "muschellij2@gmail.com", comment = c(ORCID = "0000-0001-6469-1750")),
   person("Zhian N.", "Kamvar", role = c("aut", "cph"), email = "zkamvar@gmail.com", comment = c(ORCID = "0000-0003-1458-7108")),
   person("Noam", "Ross", role = c("aut", "cph"), email = "noam.ross@gmail.com", comment = c(ORCID = "0000-0002-2136-0000")),
-  person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood"))
+  person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),
+  person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com", comment = c(github="DunLug"))
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-rticles 0.14
----------------------------------------------------------------------
-- Added citation_sorting option to change the biblatex's sorting option
-
 rticles 0.13
 ---------------------------------------------------------------------
 
@@ -12,6 +8,8 @@ rticles 0.13
 - Fixed header includes for `rjournal_article()` (thanks, @agila5 #257, @rcannood #261).
 
 - Add support for bibliography styles on the Springer template (thanks, @swhaat, #262).
+
+- Added the `citation_sorting` YAML option to change the biblatex's sorting option in `ieee_article()` output (thanks, @DunLug, #265).
 
 rticles 0.12
 ---------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+rticles 0.14
+---------------------------------------------------------------------
+- Added citation_sorting option to change the biblatex's sorting option
+
 rticles 0.13
 ---------------------------------------------------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+rticles 0.14
+---------------------------------------------------------------------
+
+- Added the `citation_sorting` YAML option to change the biblatex's sorting option in `ieee_article()` output (thanks, @DunLug, #265).
+
 rticles 0.13
 ---------------------------------------------------------------------
 
@@ -8,8 +13,6 @@ rticles 0.13
 - Fixed header includes for `rjournal_article()` (thanks, @agila5 #257, @rcannood #261).
 
 - Add support for bibliography styles on the Springer template (thanks, @swhaat, #262).
-
-- Added the `citation_sorting` YAML option to change the biblatex's sorting option in `ieee_article()` output (thanks, @DunLug, #265).
 
 rticles 0.12
 ---------------------------------------------------------------------

--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -335,7 +335,7 @@ $if(natbib)$
 \bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$
-\usepackage[backend=bibtex,citestyle=ieee,style=numeric]{biblatex}
+\usepackage[backend=bibtex,citestyle=ieee,style=numeric$if(citation_sorting)$,sorting=$citation_sorting$$endif$]{biblatex}
 $if(bibliography)$
 $for(bibliography)$
 \addbibresource{$bibliography$}

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -41,6 +41,7 @@ abstract: |
 
 bibliography: mybibfile.bib
 output: rticles::ieee_article
+#citation_sorting: none   ## used as sorting option of the biblatex package (if selected)
 ---
 
 Introduction


### PR DESCRIPTION
Hello, 
I wrote an IEEE article using the rticles templates and I needed to custom the sorting order of the citations to be 1, 2, 3...
I modified the template this way and added a citation_sorting option in Index.Rmd yaml section. I think there may be a better solution (for example as a subitem of the citation_package option) but I wanted not to modify the previous options as possible.