### PR TITLE
Springer template modifications for correct reference functionality

### DIFF
--- a/inst/rmarkdown/templates/springer_article/resources/template.tex
+++ b/inst/rmarkdown/templates/springer_article/resources/template.tex
@@ -111,7 +111,7 @@ $endif$
 
 $body$
 
-\bibliographystyle{$if(bibstyle)$ $bibstyle$ $else$spbasic$endif$}
+\bibliographystyle{$if(bibstyle)$$bibstyle$$else$spbasic$endif$}
 \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 
 \end{document}

--- a/inst/rmarkdown/templates/springer_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/springer_article/skeleton/skeleton.Rmd
@@ -41,11 +41,11 @@ output: rticles::springer_article
 
 # Introduction {#intro}
 
-Your text comes here. Separate text sections with
+Your text comes here. Separate text sections with \cite{Mislevy06Cog}.
 
 # Section title {#sec:1}
 
-Text with citations by @Galyardt14mmm, [@Mislevy06Cog].
+Text with citations by \cite{Galyardt14mmm}.
 
 ## Subsection title {#sec:2}
 
@@ -61,7 +61,3 @@ a^2+b^2=c^2
 \end{align}
 
 
-
-
-
-# References


### PR DESCRIPTION
1. The springer Rmd template had several issues that didnt allow the proper implementation of the reference style selected by the user.
- Pandoc doesnt translate markdown references (e.g. @AuthorB) to latex in the form of \cite, it translates them into \textcite{AuthorB} or \autocite{AuthorB}, which results in the creation of generic csl templated references before the actual bibliography.
- Because of the generation of those csl references, the biblatex references where not generated and the style did not change regardless of the user setting.
In order to modify this behavior, instead of the @AuthorB style, i suggest that the classic latex \cite{AuthorB} should be used. With it, these false csl references are not generated and the style of the references can be controlled with the *bibstyle* variable.
- As the references are generated automatically on the tex file with the call of the \bibliography function, it is no longer necesary to add *# References* to the Rmd. Also the *[]* are not needed as biblatex generates them automatically.

2. The latex template had white spaces around the *bibstyle*, which in case of standalone compilation of that tex file would complain.
