### PR TITLE
Set better default values for references on IEEE template

### DIFF
--- a/inst/rmarkdown/templates/ieee_article/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee_article/resources/template.tex
@@ -335,7 +335,7 @@ $if(natbib)$
 \bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$
-\usepackage[backend=bibtex,citestyle=ieee,style=numeric$if(citation_sorting)$,sorting=$citation_sorting$$endif$]{biblatex}
+\usepackage[backend=bibtex,citestyle=ieee]{biblatex}
 $if(bibliography)$
 $for(bibliography)$
 \addbibresource{$bibliography$}
@@ -632,7 +632,7 @@ $endif$
 $endif$
 $endif$
 $if(biblatex)$
-\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+\printbibliography[heading=none]
 
 $endif$
 $for(include-after)$
@@ -640,5 +640,4 @@ $include-after$
 
 $endfor$
 \end{document}
-
 

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -66,6 +66,7 @@ abstract: |
   The abstract goes here.
   On multiple lines eventually.
 
+bibtex: true
 bibliography: mybibfile.bib
 output: rticles::ieee_article
 #citation_sorting: none   ## used as sorting option of the biblatex package (if selected)
@@ -192,12 +193,12 @@ The conclusion goes here.
 Acknowledgment {#acknowledgment}
 ==============
 
-The authors would like to thank...
+The authors \cite{Feynman1963118} would like to thank...
 
 Bibliography styles
 ===================
 
-Here are two sample references: @Feynman1963118 [@Dirac1953888].
+Here are two sample references: \cite{Feynman1963118,Dirac1953888}.
 
 \newpage
 References {#references .numbered}

--- a/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee_article/skeleton/skeleton.Rmd
@@ -69,7 +69,6 @@ abstract: |
 bibtex: true
 bibliography: mybibfile.bib
 output: rticles::ieee_article
-#citation_sorting: none   ## used as sorting option of the biblatex package (if selected)
 ---
 
 Introduction


### PR DESCRIPTION
- IEEE template works by default with biblatex, it makes sense to use it as a default on the Rmd file so that users can benefit directly from its usage.
- As the package biblatex is used, the options style=numeric and sorting=none are unnecessary, as these parameters are the default for references on the IEEEtran.bst which is shipped with the ieee template., and its used when creating the references style.
- A consequence of biblatex is the citations have to be used in native latex form \cite{...}, as pandoc conversion will create \autocite or \textcite..
- biblio-title is removed as the references title can be defined directly on the Rmd file, because the references will be appended at the end of the file.
