### PR TITLE
Removing formatted_doi field from JOSS template.

### DIFF
--- a/inst/rmarkdown/templates/joss_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/joss_article/skeleton/skeleton.Rmd
@@ -22,7 +22,6 @@ affiliations:
 citation_author: Price-Whelan et. al.
 date: 13 August 2017
 year: 2017
-formatted_doi: 10.21105/joss.00388
 bibliography: paper.bib
 output: rticles::joss_article
 csl: apa.csl


### PR DESCRIPTION
This is a small change to the [JOSS](https://joss.theoj.org/) paper template to remove the `formatted_doi` field which causes production issues for JOSS and is not actually a field that we [ask for in our template](https://joss.readthedocs.io/en/latest/submitting.html#example-paper-and-bibliography).

More specifically, by including this field, the value associated overrides the parameter when it's being passed in by the JOSS Whedon bot.

This issue arose in https://github.com/openjournals/joss-reviews/issues/2028#issuecomment-578242951 when the `formatted_doi` field was left blank by the submitting author @embruna. 

Fixes https://github.com/openjournals/joss/issues/672