### PR TITLE
Better JSS multiline author support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Authors@R: c(
   person("Noam", "Ross", role = c("aut", "cph"), email = "noam.ross@gmail.com", comment = c(ORCID = "0000-0002-2136-0000")),
   person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),
   person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com"),
-  person("David M.", "Kaplan", role = c("aut", "ctb"), email = "dmkaplan2000@gmail.com", comment = c(ORCID = "0000-0001-6087-359X", github = "dmkaplan2000"))
+  person("David M.", "Kaplan", role = c("aut", "ctb"), email = "dmkaplan2000@gmail.com", comment = c(ORCID = "0000-0001-6087-359X", github = "dmkaplan2000")),
+  person(given = "Alfredo", family = "Hernández", role = c("aut", "ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"), github = "aldomann")
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.
@@ -47,6 +48,6 @@ Imports: utils, rmarkdown, knitr, yaml, tinytex (>= 0.19), xfun
 SystemRequirements: GNU make
 URL: https://github.com/rstudio/rticles
 BugReports: https://github.com/rstudio/rticles/issues
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests: testit, bookdown, xtable
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Authors@R: c(
   person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),
   person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com"),
   person("David M.", "Kaplan", role = c("aut", "ctb"), email = "dmkaplan2000@gmail.com", comment = c(ORCID = "0000-0001-6087-359X", github = "dmkaplan2000")),
-  person(given = "Alfredo", family = "Hernández", role = c("aut", "ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"), github = "aldomann")
+  person(given = "Alfredo", family = "Hernández", role = c("aut", "ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"))
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Authors@R: c(
   person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),
   person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com"),
   person("David M.", "Kaplan", role = c("aut", "ctb"), email = "dmkaplan2000@gmail.com", comment = c(ORCID = "0000-0001-6087-359X", github = "dmkaplan2000")),
-  person("Alfredo", "Hernández", role = c("aut", "ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"))
+  person("Alfredo", "Hernández", role = c("ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"))
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Authors@R: c(
   person("Robrecht", "Cannoodt", role = c("aut", "cph"), email = "rcannood@gmail.com", comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),
   person("Duncan", "Luguern", role = c("aut"), email = "duncan.luguern@gmail.com"),
   person("David M.", "Kaplan", role = c("aut", "ctb"), email = "dmkaplan2000@gmail.com", comment = c(ORCID = "0000-0001-6087-359X", github = "dmkaplan2000")),
-  person(given = "Alfredo", family = "Hernández", role = c("aut", "ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"))
+  person("Alfredo", "Hernández", role = c("aut", "ctb"), email = "aldomann.designs@gmail.com", comment = c(ORCID = "0000-0002-2660-4545"))
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.
@@ -48,6 +48,6 @@ Imports: utils, rmarkdown, knitr, yaml, tinytex (>= 0.19), xfun
 SystemRequirements: GNU make
 URL: https://github.com/rstudio/rticles
 BugReports: https://github.com/rstudio/rticles/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.0.2
 Suggests: testit, bookdown, xtable
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.15
 ---------------------------------------------------------------------
 
+- Fixed issue with multi-line authors on JSS template when using `\AND` (firstly implemented in https://github.com/rstudio/rticles/commit/b740b19b90cd6f7afe2cd7d66456c9efa0bb4cdf).
+
 
 rticles 0.14
 ---------------------------------------------------------------------

--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -30,7 +30,7 @@ jss_article <- function(..., keep_tex = TRUE, citation_package = 'natbib') {
     if (is.function(post)) output = post(metadata, input, output, clean, verbose)
     f <- xfun::with_ext(output, '.tex')
     x <- xfun::read_utf8(f)
-    x <- gsub('( \\\\AND )\\\\And ', '\\1', x)
+    x <- gsub('(\\\\AND )\\\\And ', '\\1', x)
     x <- gsub(' \\\\AND(\\\\\\\\)$', '\\1', x)
     xfun::write_utf8(x, f)
     tinytex::latexmk(


### PR DESCRIPTION
In some cases, when using authors in multiple lines with the `\AND` command (see #100 and https://github.com/rstudio/rticles/commit/b740b19b90cd6f7afe2cd7d66456c9efa0bb4cdf), the TeX file will result in `\AND \And` at the start of a new line (example shown below). This makes 
```r
x <- gsub('( \\\\AND )\\\\And ', '\\1', x)
``` 
replacement not able to get rid of `\And`. This small fix is able to handle this special case as well as the previous replacement cases.

## Example of problematic TeX author field
```tex
\author{
Main author\\University of life and more \And Second author\\University
of life and more \And Third Author\\University of life and more
\AND \And Fourth Author\\University of life and more \And Fifth
Author\\University of life and more \And Sixth Author\\University of
life and more \AND Seventh Author\\University of life and
more \And Eighth Author\\University of life and more \And Ninth
Author\\University of life and more
}
```
![image](https://user-images.githubusercontent.com/729732/82057548-683b7800-96bb-11ea-9305-7b04beb5f533.png)
