### PR TITLE
Implemented some of the suggestions from #254 to jss_article

### DIFF
--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -32,6 +32,7 @@ jss_article <- function(..., keep_tex = TRUE, citation_package = 'natbib') {
     x <- xfun::read_utf8(f)
     x <- gsub('( \\\\AND )\\\\And ', '\\1', x)
     x <- gsub(' \\\\AND(\\\\\\\\)$', '\\1', x)
+    x <- gsub("\\\\texttt\\{", "\\\\code\\{", x)
     xfun::write_utf8(x, f)
     tinytex::latexmk(
       f, base$pandoc$latex_engine,

--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -45,7 +45,7 @@ jss_article <- function(..., keep_tex = TRUE, citation_package = 'natbib') {
   }
   hook_input <- function(x, options) {
     if (options$prompt && length(x)) {
-      x <- gsub("\\n", paste0("\n", "R+ "), x)
+      x <- gsub("\\n", paste0("\n", "+ "), x)
       x <- paste0("R> ", x)
     }
     paste0(c('\n\\begin{CodeInput}', x, '\\end{CodeInput}', ''),

--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -32,7 +32,6 @@ jss_article <- function(..., keep_tex = TRUE, citation_package = 'natbib') {
     x <- xfun::read_utf8(f)
     x <- gsub('( \\\\AND )\\\\And ', '\\1', x)
     x <- gsub(' \\\\AND(\\\\\\\\)$', '\\1', x)
-    x <- gsub("\\\\texttt\\{", "\\\\code\\{", x)
     xfun::write_utf8(x, f)
     tinytex::latexmk(
       f, base$pandoc$latex_engine,

--- a/inst/rmarkdown/templates/jss_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jss_article/skeleton/skeleton.Rmd
@@ -33,16 +33,12 @@ This template demonstrates some of the basic latex you'll need to know to create
 
 ## Code formatting
 
-Markdown backticks syntax is reserved for the \code{} environment,
-used for inline code. 
-
-* `print("abc")` renders \code{print("abc")}
-
-For highlighting programming languages and packages,
-instead use the more precise latex commands:
+In general, don't use Markdown, but use the more precise LaTeX commands instead:
 
 * \proglang{Java}
 * \pkg{plyr}
+
+One exception is inline code, which can be written inside a pair of backticks (i.e., using the Markdown syntax).
 
 # R code
 

--- a/inst/rmarkdown/templates/jss_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jss_article/skeleton/skeleton.Rmd
@@ -33,11 +33,16 @@ This template demonstrates some of the basic latex you'll need to know to create
 
 ## Code formatting
 
-Don't use markdown, instead use the more precise latex commands:
+Markdown backticks syntax is reserved for the \code{} environment,
+used for inline code. 
+
+* `print("abc")` renders \code{print("abc")}
+
+For highlighting programming languages and packages,
+instead use the more precise latex commands:
 
 * \proglang{Java}
 * \pkg{plyr}
-* \code{print("abc")}
 
 # R code
 


### PR DESCRIPTION
#254

> **Continuation prompts**
> 
> At the moment rticles employs either R+ (for evaluated code) or R> (for non-evaluated code) as the continution prompt but + would be requested by JSS.

The code chunk

```{r}
f(a = 1,
  b = 2)
```

now correctly renders as the journal template example

```
R> f(a = 1,
+    b = 2)
```

> **Inline code formatting**
> 
> For code in Markdown it is ok to use backtick syntax, so that `\code{...}` is typically not necessary. Hence I it is ok to remove `\code{print("abc")}` from `skeleton.Rmd`, I think.

Changed the way markdown backtick syntax renders to `\code{}` instead of `texttt{}` and documented in the `skeleton.Rmd`