### PR TITLE
Added missing header-includes for the Biometrics template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rticles 0.15
 ---------------------------------------------------------------------
 
-- Added missing header-includes for the Biometrics template (thanks, @haozhu233, #296)
+- Added the missing support for `header-includes` to the Biometrics template (thanks, @haozhu233, #296).
 
 rticles 0.14
 ---------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rticles 0.15
 ---------------------------------------------------------------------
 
+- Added missing header-includes for the Biometrics template (thanks, @haozhu233, #296)
 
 rticles 0.14
 ---------------------------------------------------------------------

--- a/inst/rmarkdown/templates/biometrics_article/resources/template.tex
+++ b/inst/rmarkdown/templates/biometrics_article/resources/template.tex
@@ -62,6 +62,10 @@ $endif$
 \author{$for(author)$ $author.name$ \email{$author.email$} \\ $author.affiliation$ $sep$ \and
 		$endfor$
 	   }
+	   
+$for(header-includes)$
+$header-includes$
+$endfor$
 
 \begin{document}
 


### PR DESCRIPTION
A friend of mine brought to my attention that the biometrics template lacks the header-includes loop. Here is the fix. Thanks! :)