### PR TITLE
* hyperref 类选项已经 deprecated，hyperref 宏包会自动加载，所以不再需要它了。

### DIFF
--- a/inst/rmarkdown/templates/ctex/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ctex/skeleton/skeleton.Rmd
@@ -10,7 +10,6 @@ output:
     fig_caption: yes
     number_sections: yes
     toc: yes
-classoption: "hyperref,"
 ---
 
 # 引言


### PR DESCRIPTION
## 问题

编译 rticles 自带的 ctex 中文 R Markdown 模版，目前已经出现如下警告

```
Warning message:
Package ctex Warning: Option `hyperref' is deprecated.
(ctex)                `hyperref' package will be loaded.
```

可见 hyperref 类选项已经 deprecated，上游 ctex 文类会自动加载 hyperref 宏包，所以不再需要它了。

