### PR TITLE
add a affiliation2 field in JSS template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.15
 ---------------------------------------------------------------------
 
+- Added a `author.affiliation2` field in `jss_article()` template to provide another affiliation to be used in the adress field in place of `author.affiliation`. This allow differently formated affiliation for example. (thanks, @aldomann, #291) 
+
 - Improved the `jss_article()` format: Short titles can now be provided to headers to escape code/math in section titles, the continuation prompt has been corrected (from `R+` to `+`), and the skeleton document has been updated accordingly (thanks, @statibk #254, @Freguglia #294).
 
 - Fixed `elsevier_article()` template so that chunk option `out.width` can be set. (thanks, @EddieItelman, #300)

--- a/inst/rmarkdown/templates/jss_article/resources/template.tex
+++ b/inst/rmarkdown/templates/jss_article/resources/template.tex
@@ -45,7 +45,11 @@ $endif$
 $for(author)$
   $if(author.address)$
   $author.name$\\
+  $if(author.affiliation2)$
+  $author.affiliation2$\\
+  $else$
   $author.affiliation$\\
+  $endif$
   $author.address$\\
   $if(author.email)$E-mail: $author.email$\\$endif$
   $if(author.url)$URL: $author.url$\\~\\$endif$

--- a/inst/rmarkdown/templates/jss_article/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jss_article/skeleton/skeleton.Rmd
@@ -3,6 +3,7 @@ documentclass: jss
 author:
   - name: FirstName LastName
     affiliation: University/Company
+    # use this syntax to add text on several lines
     address: |
       | First line
       | Second line
@@ -12,7 +13,15 @@ author:
     affiliation: 'Affiliation \AND'
     # To add another line, use \AND at the end of the previous one as above
   - name: Third Author
-    affiliation: Affiliation
+    address: |
+      | Department of Statistics and Mathematics,
+      | Faculty of Biosciences,
+      | Universitat Autònoma de Barcelona
+    affiliation: |
+      | Universitat Autònoma 
+      | de Barcelona
+    # use a different affiliation in adress field (differently formated here)
+    affiliation2: Universitat Autònoma de Barcelona
 title:
   formatted: "A Capitalized Title: Something about a Package \\pkg{foo}"
   # If you use tex in the formatted title, also supply version without


### PR DESCRIPTION
This will close #291 

This new `affiliation2` field will be used instead of `affiliation` if provided. This allow to provide  a differently formated affiliation if necessary to be used in the Adress part of the template. 

Ex: with a newline in author field and not newline in adresse field.

From the example in #291 
````md
---
documentclass: jss
author:
  - name: Alfredo Hernández
    affiliation: |
      | Universitat Autònoma 
      | de Barcelona
    address: |
      | Department of Statistics and Mathematics,
      | Faculty of Biosciences,
      | Universitat Autònoma de Barcelona
    affiliation2: Universitat Autònoma de Barcelona
    email: \email{aldomann.designs@gmail.com}
    url: \url{aldomann.com}
  - name: David Endesfelder
    affiliation: Bundesamt für Strahlenschutz
  - name: Joan Francesc Barquinero
    affiliation: |
      | Universitat Autònoma 
      | de Barcelona
    address: |
      | Department of Statistics and Mathematics,
      | Faculty of Biosciences,
      | Universitat Autònoma de Barcelona
    # use a differently formated affiliation in author field and adresse field
    affiliation2: Universitat Autònoma de Barcelona
title:
  formatted: "\\pkg{Biodose Tools}: An \\proglang{R} \\proglang{Shiny} Application for Biological Dosimetry"
  # If you use tex in the formatted title, also supply version without
  plain:     "Biodose Tools: An R Shiny Application for Biological Dosimetry"
  # For running headers, if needed
  short:     "\\pkg{Biodose Tools}: An \\proglang{R} \\proglang{Shiny} Application for Biological Dosimetry"
abstract: >
  Lorem ipsum.
keywords:
  # at least one keyword must be supplied
  formatted: [keywords, not capitalized, "\\proglang{R}"]
  plain:     [keywords, not capitalized, R]
preamble: >
  \usepackage{amsmath}
output: rticles::jss_article
---

# Introduction

This template demonstrates some of the basic latex you'll need to know to create a JSS article.
````

![image](https://user-images.githubusercontent.com/6791940/90389394-c8aace80-e089-11ea-9026-2f76313ae58f.png)

It has been documented in the `skeleton.Rmd`

I believe this answer the feature request in #291 - right @aldomann ? 