### PR TITLE
set rmarkdown minimum requirement to 1.16 so that latex-div.lua is available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Authors@R: c(
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.
 License: GPL-3
-Imports: utils, rmarkdown, knitr, yaml, tinytex (>= 0.19), xfun
+Imports: utils, rmarkdown (>= 1.16), knitr, yaml, tinytex (>= 0.19), xfun
 SystemRequirements: GNU make
 URL: https://github.com/rstudio/rticles
 BugReports: https://github.com/rstudio/rticles/issues


### PR DESCRIPTION
I was conservative and only set the minimum working version for latex-div.lua to work. 

We could be more up to date and set to `>= 2.3`, the last CRAN version. 

I opened the PR so that you can advice and choose.