### PR TITLE
Update Copernicus template to 6.0 and sanitize #331

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rticles 0.17
 ---------------------------------------------------------------------
-
+- Update Copernicus Publications template to version 6.0 (#331) and sanitize 
+and issue that caused `pdftex` from hanging.
 
 
 rticles 0.16

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -89,6 +89,7 @@ copernicus_journals <- list(
   "Geoscientific Model Development" = "gmd",
   "History of Geo- and Space Sciences" = "hgss",
   "Hydrology and Earth System Sciences" = "hess",
+  "Journal of Bone and Joint Infection" = "jbji",
   "Journal of Micropalaeontology" = "jm",
   "Journal of Sensors and Sensor Systems" = "jsss",
   "Magnetic Resonance" = "mr",

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_0.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_0.txt
@@ -1,7 +1,7 @@
-File: README_copernicus_package_5_8.txt
+File: README_copernicus_package_6_0.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 5.8, 3 February 2020
+copernicus_package.zip in the version 6.0, 25 June 2020
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -15,8 +15,8 @@ URL:   	https://publications.copernicus.org
 
 
 Content:
-- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.08, 31 January 2020
-- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 13 November 2019
+- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.11, 24 June 2020
+- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 25 June 2020
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.2, September 2017 
 - natbib.sty
 - pdfscreencop.sty / pdfscreen.sty

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -10,6 +10,7 @@
 %% Please use the following documentclass and journal abbreviations for discussion papers and final revised papers.
 
 %% 2-column papers and discussion papers
+\RequirePackage[2020/02/02]{latexrelease}
 \documentclass[$journal$, manuscript]{copernicus}
 
 

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -43,6 +43,7 @@
 % Geoscientific Model Development (gmd)
 % History of Geo- and Space Sciences (hgss)
 % Hydrology and Earth System Sciences (hess)
+% Journal of Bone and Joint Infection (jbji)
 % Journal of Micropalaeontology (jm)
 % Journal of Sensors and Sensor Systems (jsss)
 % Magnetic Resonance (mr)

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
@@ -1,9 +1,10 @@
 \newif\ifprp             \DeclareOption{prp}     {\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue                  \@bartrue \prptrue}
 \newif\ifgtes            \DeclareOption{gtes}    {\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue                  \@bartrue \gtestrue}
 \newif\ifcopyediting     \DeclareOption{copyediting}{\copyeditingtrue\@noreftrue}
+\newif\ifjbji  \DeclareOption{jbji}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\jbjitrue}
 \newif\ifmr  \DeclareOption{mr}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@twostagejnltrue\mrtrue}
             \DeclareOption{mrd}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@stage@finalfalse\mrtrue}
-\newif\ifejm  \DeclareOption{ejm}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\ejmtrue}
+\newif\ifejm  \DeclareOption{ejm}{\@abstractcenteredtrue\@bartrue\ejmtrue}
 \newif\ifwcd  \DeclareOption{wcd}{\@twostagejnltrue\wcdtrue}
             \DeclareOption{wcdd}{\@stage@finalfalse\wcdtrue}
 \newif\ifgchron  \DeclareOption{gchron}{\@sansseriffacetrue\@sansserifheadertrue\@twostagejnltrue\gchrontrue}
@@ -992,7 +993,6 @@
   \def\@journallogo{\includegraphics{EJM_Logo.pdf}}
   \definecolor{textcol}{rgb}{0.0,0.0,0.0}
   \definecolor{bgcol}{rgb}{1,1,1}
-  \definecolor{barcol}{rgb}{0.0,0.0,0.0}
   \definecolor{rulecol}{rgb}{1.0,1.0,1.0}
 \fi
 \ifmr%classical
@@ -1019,6 +1019,20 @@
       \definecolor{buttontext}{rgb}{1.0,1.0,1.0}
     \fi
   \fi
+\fi
+\ifjbji%classical
+  \def\@journalname{Journal of Bone and Joint Infection}
+  \def\@journalnameabbreviation{J. Bone Joint Infect.}
+  \def\@journalnameshort{JBJI}
+  \def\@journalnameshortlower{jbji}
+  \def\@journalstartyear{2016}
+  \def\@sentence{Published by Copernicus Publications on behalf of the European Bone and Joint Infection Society.}
+  \def\@journalurl{https://jbji.copernicus.org/}
+  \def\@journallogo{\includegraphics{JBJI_Logo.pdf}}
+  \definecolor{textcol}{rgb}{0.161,0.337,0.361}
+  \definecolor{bgcol}{rgb}{1,1,1}
+  \definecolor{barcol}{rgb}{1.0,1.0,1.0}
+  \definecolor{rulecol}{rgb}{0.161,0.337,0.361}
 \fi
 
 }

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
@@ -5,18 +5,18 @@
 %% The original source files were:
 %%
 %% copernicus.dtx  (with options: `class')
-%%
+%% 
 %% -----------------------------------------------------------------
 %% Author:     copernicus.org and le-tex publishing services
-%%
+%% 
 %% This file is part of the copernicus package for papers
 %% published by Copernicus Publications (Copernicus GmbH).
-%%
+%% 
 %%       Copyright (C) 2020 by Copernicus Publications
 %% -----------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{copernicus}
-    [2020/01/31 9.08 Copernicus papers]
+    [2020/06/24 9.11 Copernicus papers]
 \frenchspacing
 \clubpenalty10000
 \widowpenalty10000
@@ -290,10 +290,13 @@
   \@journalnameabbreviation
   \ifcopyediting\else\if@noref,\space\@msnumber\else,\space\@pvol, \@fpage\if@nolastpage\else{--\@lpage}\fi\fi, \@pyear\fi}
 \def\@journalurlInfo{%
+  %% URL raus, DOI rein; 2020-05-15
   \if@preface
-    \@journalurl\ifcopyediting\else/\preface@abbrev.pdf\fi
+    %\@journalurl\ifcopyediting\else/\preface@abbrev.pdf\fi
+    https://doi.org/10.5194/\preface@abbrev.pdf
   \else
-    \@journalurl\ifcopyediting\else/\if@noref\@msnumber\else\@pvol/\@fpage/\@pyear\fi/\fi
+    https://doi.org/10.5194/\if@noref\@msnumber\else\@journalnameshortlower-\@pvol-\@fpage-\@pyear\fi
+    %\@journalurl\ifcopyediting\else/\if@noref\@msnumber\else\@pvol/\@fpage/\@pyear\fi/\fi
   \fi}
 \def\runningheaderfont{%
   \if@stage@final%spec. obsolete ?
@@ -1166,8 +1169,10 @@
 \RequirePackage[normalem]{ulem}%
 \RequirePackage[T1]{fontenc}
 \RequirePackage{textcomp}
-\RequirePackage{fontawesome5}
-\RequirePackage{fontawesome}
+\if@cop@home
+  \RequirePackage{fontawesome5}
+  \RequirePackage{fontawesome}
+\fi
 \ifx\xmltexversion\@undefined
   \RequirePackage[utf8]{inputenc}
   \def\strip@x#1x#2\@nil{#1}%
@@ -1375,8 +1380,10 @@
       {\ifnewaffil\addtocounter{affil}{1}%
        \xdef\AB@thenote{\arabic{affil}}\fi
        \global\advance\c@authnum\@ne
-       \expandafter\ifx\csname deceased@\the\c@authnum\endcsname\true\relax\def\@@deceased{$^{,\text{\faCross}}$}\fi
-       \expandafter\ifx\csname econtrib@\the\c@authnum\endcsname\true\relax\def\@@econtrib{$^{,\text{\faStar}}$}\fi
+       \if@cop@home
+         \expandafter\ifx\csname deceased@\the\c@authnum\endcsname\true\relax\def\@@deceased{$^{,\text{\faCross}}$}\fi
+         \expandafter\ifx\csname econtrib@\the\c@authnum\endcsname\true\relax\def\@@econtrib{$^{,\text{\faStar}}$}\fi
+       \fi
        \def\@tempa{#1}\ifx\@tempa\@empty\def\AB@note{\AB@thenote}\else\def\AB@note{#1}%
         \setcounter{Maxaffil}{0}\fi
       \ifnum\value{authors}>1\relax
@@ -1450,6 +1457,7 @@
   \if!#2!\else\econtrib@sep#2\@nil\fi}
 
 \newcommand\deceased[2][]{\gdef\@deceasedtext{#1}\@deceased{#2}}
+\if@cop@home
 \def\@deceased#1{%
   \ifx\@deceasedtext\@empty\gdef\@deceasedNote{deceased}\else\gdef\@deceasedNote{deceased, \@deceasedtext}\fi
    \deceased@sep#1,\@nil
@@ -1464,7 +1472,10 @@
    \protected@xdef\AB@affillist{\the\@temptokena \AB@affilsep
      \AB@affilnote{\faStar}\protect\Affilfont\@econtribNote}%
  }
-
+\else
+  \let\equalcontrib\@gobble
+  \let\@deceased\@gobble
+\fi
 \def\Author{\@ifnextchar[\@Author{\@Author[]}}%]
 \def\@Author[#1]{%
   \def\@tempa{#1}%
@@ -1841,6 +1852,8 @@
     \DeclareSymbolFont{largesymbolsA}{U}{esint}{m}{n}%from esint.sty
     \DeclareMathSymbol{\oiintop}{\mathop}{largesymbolsA}{'015}%from esint.sty
     \def\oiint{\oiintop\nolimits}%from esint.sty
+    \DeclareMathSymbol{\fintop}{\mathop}{largesymbolsA}{'037}%from esint.sty
+    \def\fint{\fintop\nolimits}%from esint.sty
     \ifx\xmltexversion\@undefined\else{\catcode`\_=\active\global\let_\xmltexUndersc@re}\fi
     \if@sansserifface
       \DeclareMathVersion{sans}


### PR DESCRIPTION
Update Copernicus Publications template as discussed previously and, hopefully, sanitize #331 until a new version gets released by Copernicus. I tested the fix on my machine and it works as expected.

- [X] Unless you have done it in any other RStudio's projects before, please sign the [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement for a significant pull request (it is fine not to sign it if a PR is only intended to fix a few typos). You can send the signed copy to <jj@rstudio.com>.

*Note: If I run the checks, some tests throw errors, however, none of them related to the Copernicus template.*
