### PR TITLE
Fix JSS template by pinning the version of latexrelease package

### DIFF
--- a/inst/rmarkdown/templates/jss/resources/template.tex
+++ b/inst/rmarkdown/templates/jss/resources/template.tex
@@ -1,3 +1,6 @@
+% To remove when JSS.cls is fixed
+% https://github.com/rstudio/rticles/issues/329
+\RequirePackage[2020/02/02]{latexrelease}
 \documentclass[
 $for(classoption)$
   $classoption$$sep$,


### PR DESCRIPTION
Same fix as in  36f461dc3efae883369a88086761318848e522b0 by pining the latexrelease package to older version (https://topanswers.xyz/tex?q=1416)

This should close #329  and fix the travis build https://github.com/rstudio/rticles/pull/335#issuecomment-710149989

let's see what travis think of that