### PR TITLE
AMS template.tex: Fix brace in author2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rticles
 Type: Package
 Title: Article Formats for R Markdown
-Version: 0.16.1
+Version: 0.16.2
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.17
 ---------------------------------------------------------------------
 
+- Fixes `ams_article()` template regarding authors insertion (thanks, #340, @ConorIA)
+
 - Update Copernicus Publications template to version 6.0 (#331) and sanitize 
 and issue that caused `pdftex` from hanging.
 

--- a/inst/rmarkdown/templates/ams/resources/template.tex
+++ b/inst/rmarkdown/templates/ams/resources/template.tex
@@ -26,12 +26,13 @@ $if(author1)$
 $if(correspondingauthor)$
 \correspondingauthor{$author1$,$correspondingauthor$}
 $endif$
-$endif$
 $if(author2)$
 and $author2$
 $if(currentaddress)$
-\thanks{$currentaddress$}}
+\thanks{$currentaddress$}
 $endif$
+$endif$
+}
 $endif$
 $if(affiliation)$
 \affiliation{$affiliation$}


### PR DESCRIPTION
As written, the authors block is never closed when there is no `\currentaddress for author 2`. I've also moved the closing $endif$ for $if(author1)$ so that we don't end up with a stray brace when no authors are specified.