### PR TITLE
Update Copernicus template to version 6.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rticles 0.18
 ---------------------------------------------------------------------
-
+- Update Copernicus Publications template to version 6.1. This is includes a final 
+fix for the LaTeX problem sanitized with the last `rticles` update (thanks, @RLumSK, #331).
 
 rticles 0.17
 ---------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Currently included templates and their contributors are the following:
 | [Bioinformatics](https://academic.oup.com/bioinformatics) | [@ShixiangWang](https://github.com/ShixiangWang) | [#297](https://github.com/rstudio/rticles/pull/297) | `bioinformatics_article()` |
 | [Biometrics](https://biometrics.biometricsociety.org) | [@daltonhance](https://github.com/daltonhance) | [#170](https://github.com/rstudio/rticles/pull/170) | `biometrics_article()` |
 | [Bulletin de l'AMQ](https://www.amq.math.ca/bulletin/) | [@desautm](https://github.com/desautm) | [#145](https://github.com/rstudio/rticles/pull/145) | `amq_article()` |
-| [Copernicus Publications](https://publications.copernicus.org) | [@nuest](https://github.com/nuest), [@RLumSK](https://github.com/RLumSK) | [#172](https://github.com/rstudio/rticles/pull/172), [#336](https://github.com/rstudio/rticles/pull/336) | `copernicus_article()` |
+| [Copernicus Publications](https://publications.copernicus.org) | [@nuest](https://github.com/nuest), [@RLumSK](https://github.com/RLumSK) | [#172](https://github.com/rstudio/rticles/pull/172), [#342](https://github.com/rstudio/rticles/pull/342) | `copernicus_article()` |
 | [CTeX](https://ctan.org/pkg/ctex) |  |  | `ctex()` |
 | [Elsevier](https://www.elsevier.com) | [@cboettig](https://github.com/cboettig) | [#27](https://github.com/rstudio/rticles/pull/27) | `elsevier_article()` |
 | [Frontiers](https://www.frontiersin.org/) | [@muschellij2](https://github.com/muschellij2) | [#211](https://github.com/rstudio/rticles/pull/211) | `frontiers_article()` |

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_1.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_1.txt
@@ -1,7 +1,7 @@
-File: README_copernicus_package_6_0.txt
+File: README_copernicus_package_6_1.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 6.0, 25 June 2020
+copernicus_package.zip in the version 6.1, 29 October 2020
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -15,9 +15,8 @@ URL:   	https://publications.copernicus.org
 
 
 Content:
-- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.11, 24 June 2020
+- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.21, 20 October 2020
 - copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 25 June 2020
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.2, September 2017 
-- natbib.sty
 - pdfscreencop.sty / pdfscreen.sty
 - template.tex: A LaTeX template in journal style.

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -10,7 +10,6 @@
 %% Please use the following documentclass and journal abbreviations for discussion papers and final revised papers.
 
 %% 2-column papers and discussion papers
-\RequirePackage[2020/02/02]{latexrelease}
 \documentclass[$journal$, manuscript]{copernicus}
 
 

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
@@ -16,7 +16,7 @@
 %% -----------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{copernicus}
-    [2020/06/24 9.11 Copernicus papers]
+    [2020/10/29 9.21 Copernicus papers]
 \frenchspacing
 \clubpenalty10000
 \widowpenalty10000
@@ -737,18 +737,23 @@
                \ifx\specialp@perstring\@undefined
                  \if!\@recvd!
                  \else
+                   \setbox\z@\hbox\bgroup
                      \strut\hbox{Received:\nobreakspace\@recvd}%
-                   \def\datesep{ -- }%
-                   \if@twostagejnl\ifx\@pubdiscuss\@empty\else
-                     \datesep \hbox{Discussion started:\nobreakspace\@pubdiscuss}\def\datesep{\newline\def\datesep{ -- }}%
-                   \fi\fi
-                   \if!\@revsd!\else\datesep \hbox{Revised:\nobreakspace\@revsd}\fi
-                   \if!\@accptd!\else\datesep \hbox{Accepted:\nobreakspace\@accptd}\fi
-                   \ifx\@published\@undefined\else\datesep\fi
+                     \def\datesep{ -- }%
+                     \if@twostagejnl\ifx\@pubdiscuss\@empty\else
+                         \datesep \hbox{Discussion started:\nobreakspace\@pubdiscuss}\def\datesep{\newline\def\datesep{ -- }}%
+                       \fi
+                     \fi
+                     \if!\@revsd!\else\datesep \hbox{Revised:\nobreakspace\@revsd}\fi
+                     \if!\@accptd!\else\datesep \hbox{Accepted:\nobreakspace\@accptd}\fi
+                     \ifx\@published\@undefined\else\datesep\fi
+                   \egroup
+                   \unhcopy\z@
+                   \ifdim\wd\z@>100mm\strut\newline\strut\fi
                  \fi
                \fi
-               \ifx\@published\@undefined\else Published:\nobreakspace\@published\fi
-               \par\egroup
+               \ifx\@published\@undefined\else \hbox{Published:\nobreakspace\@published}\fi
+               \strut\par\egroup
                \ifx\@howtocite\@empty\else\item[{How to cite:}]\@howtocite\fi
                \ifx\abstractexists\@undefined
                \else
@@ -1123,6 +1128,12 @@
   \def\fnum@figure{\rmfamily\bfseries\figurename\nobreakspace\thefigure}
   \def\fnum@table{\rmfamily\bfseries\tablename\nobreakspace\thetable}
 \fi
+\def\mytextcircled#1{%
+  \textcircled{\ifx\in@caption\relax
+    \check@mathfonts\fontsize\ssf@size\z@\math@fontsfalse\selectfont\kern-1\p@
+  \else
+    \check@mathfonts\fontsize\sf@size\z@\math@fontsfalse\selectfont
+  \fi #1}}
 \long\def\@makecaption#1#2{%
   \def\@tempa{figure}\ifx\@captype\@tempa
     \if@stage@final
@@ -1131,7 +1142,7 @@
       \vskip\abovecaptionskip\goodbreak
     \fi
   \fi
-  {\reset@font\small{\bfseries#1.} #2\par}%
+  {\let\in@caption\relax\reset@font\small{\bfseries#1.} #2\par}%
   \if@cop@home\ifonline\ifnum\csname c@\@captype\endcsname=1 % for 1st fig or tab only
     \immediate\write\@auxout{\string\gdef\string\@num\@captype{}}%
     \hypertarget{\@captype}{}%
@@ -1186,6 +1197,7 @@
 \edef\@classoptionslist{english,\old@classoptionslist}
 \RequirePackage{babel}
 \let\@classoptionslist\old@classoptionslist
+\ifx\StandardLayout\@undefined\let\StandardLayout\relax\fi
 \def\@tempa{french}\ifx\bbl@main@language\@tempa
   \StandardLayout
   %% Switch to quotation marks with additional horizontal spacing
@@ -1728,13 +1740,14 @@
   {\CopernicusWarningNoLine{Cannot find subfloat.sty; proceeding without it}}
 \RequirePackage[authoryear,round]{natbib}
 \def\NAT@sort{0}\def\NAT@cmprs{0}
-\renewcommand\NAT@sep{;} \renewcommand\NAT@cmt{, }
-\renewcommand\NAT@aysep{,} \renewcommand\NAT@yrsep{, }
+\bibstyle{copernicus}
 \setlength\bibsep\z@
 \let\bibfont\small
-\NAT@numbersfalse
-\NAT@set@cites
-\let\NAT@set@cites\relax
+\renewcommand\bibitem{\@ifnextchar[{\@lbibitem}{\@lbibitem[??(????)]}}%]
+\ifx\xmltexversion\@undefined\else
+  \NAT@set@cites
+  \let\NAT@set@cites\relax
+\fi
 \AtBeginDocument{\let\@citex\NAT@citex}
 \newcommand\urlprefix{}
 \renewenvironment{thebibliography}[1]
@@ -1848,6 +1861,9 @@
     \provide@orig@symbol{Phi}
     \provide@orig@symbol{Psi}
     \provide@orig@symbol{Omega}
+    %% Fix fuer #6924, vgl https://tex.stackexchange.com/questions/561236/setmathalphabet-messes-with-rm
+    \usepackage{etoolbox}%
+    \patchcmd\document@select@group{#1{#4}}{\expandafter#1\ifx\math@bgroup\bgroup{#4}\else#4\fi}{}{\fail}%
     \RequirePackage[mtbold]{mathtime}
     \DeclareSymbolFont{largesymbolsA}{U}{esint}{m}{n}%from esint.sty
     \DeclareMathSymbol{\oiintop}{\mathop}{largesymbolsA}{'015}%from esint.sty


### PR DESCRIPTION
This PR includes the already announced final fix for #331, which was released by Copernicus today in the morning.

- [X] Unless you have done it in any other RStudio's projects before, please sign the [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement for a significant pull request (it is fine not to sign it if a PR is only intended to fix a few typos). You can send the signed copy to <jj@rstudio.com>.

- [X] Update NEWS.