### PR TITLE
Update jss.cls

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^\.travis\.yml$
 ^\.github$
 ^README\.md$
+^tools/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.18
 ---------------------------------------------------------------------
 
+- Update jss.cls to version 3.2 (#329).
+
 - Options can now be passed to `hyperref` packages using `header-includes` and `\PassOptionsToPackage` in the AEA template (thanks, @nurfatimaj, #334)
 
 - Update Copernicus Publications template to version 6.1. This is includes a final 

--- a/inst/rmarkdown/templates/jss/resources/template.tex
+++ b/inst/rmarkdown/templates/jss/resources/template.tex
@@ -1,6 +1,3 @@
-% To remove when JSS.cls is fixed
-% https://github.com/rstudio/rticles/issues/329
-\RequirePackage[2020/02/02]{latexrelease}
 \documentclass[
 $for(classoption)$
   $classoption$$sep$,

--- a/inst/rmarkdown/templates/jss/skeleton/jss.cls
+++ b/inst/rmarkdown/templates/jss/skeleton/jss.cls
@@ -1,28 +1,8 @@
 %%
-%% This is file `jss.cls',
-%% generated with the docstrip utility.
-%%
-%% The original source files were:
-%%
-%% jss.dtx  (with options: `class')
-%% 
-%% IMPORTANT NOTICE:
-%% 
-%% For the copyright see the source file.
-%% 
-%% Any modified versions of this file must be renamed
-%% with new filenames distinct from jss.cls.
-%% 
-%% For distribution of the original source see the terms
-%% for copying and modification in the file jss.dtx.
-%% 
-%% This generated file may be distributed as long as the
-%% original source files, as listed above, are part of the
-%% same distribution. (The sources need not necessarily be
-%% in the same archive or directory.)
-\def\fileversion{3.0}
+%% This is file `jss.cls'
+\def\fileversion{3.2}
 \def\filename{jss}
-\def\filedate{2015/09/01}
+\def\filedate{2020/12/09}
 %%
 %% Package `jss' to use with LaTeX2e for JSS publications (http://www.jstatsoft.org/)
 %% License: GPL-2 | GPL-3
@@ -74,6 +54,7 @@
 \RequirePackage{graphicx,color,ae,fancyvrb}
 \RequirePackage[T1]{fontenc}
 \IfFileExists{upquote.sty}{\RequirePackage{upquote}}{}
+\IfFileExists{lmodern.sty}{\RequirePackage{lmodern}}{}
 %% bibliography
 \if@shortnames
   \usepackage[authoryear,round]{natbib}
@@ -486,14 +467,14 @@
 \if@notitle
   %% \AtBeginDocument{\maketitle}
 \else
-  \AtBeginDocument{\maketitle}
+  \@ifundefined{AddToHook}{\AtBeginDocument{\maketitle}}{\AddToHook{begindocument}[maketitle]{\maketitle}}
 \fi
 %% commands
 \newcommand\code{\bgroup\@makeother\_\@makeother\~\@makeother\$\@codex}
 \def\@codex#1{{\normalfont\ttfamily\hyphenchar\font=-1 #1}\egroup}
 %%\let\code=\texttt
 \let\proglang=\textsf
-\newcommand{\pkg}[1]{{\fontseries{b}\selectfont #1}}
+\newcommand{\pkg}[1]{{\fontseries{m}\fontseries{b}\selectfont #1}}
 \newcommand{\email}[1]{\href{mailto:#1}{\normalfont\texttt{#1}}}
 \ifx\csname urlstyle\endcsname\relax
   \newcommand\@doi[1]{doi:\discretionary{}{}{}#1}\else

--- a/tools/update_cls.R
+++ b/tools/update_cls.R
@@ -1,0 +1,19 @@
+# Helper script for updating .cls file in this package
+
+# JSS article -------------------------------------------------------------
+# From https://www.jstatsoft.org/pages/view/style
+dir.create(tmp_dir <- tempfile())
+bundle <- "https://www.jstatsoft.org/public/journals/1/jss-article-tex.zip"
+new_jss <- xfun::in_dir(tmp_dir, {
+  xfun::download_file(bundle)
+  unzip(basename(bundle))
+  xfun::normalize_path("jss.cls")
+})
+file.copy(new_jss,
+          "inst/rmarkdown/templates/jss/skeleton/jss.cls",
+          overwrite = TRUE)
+unlink(tmp_dir, recursive = TRUE)
+# Check git diff and commit
+
+
+


### PR DESCRIPTION
This will close #329 and revert https://github.com/rstudio/rticles/pull/337 by updating `jss.cls` which contains the fix from upstream. 

I took the opportunity to start a helper script that will contains R code to help with `.cls` updating

