### PR TITLE
Adds some more variables to arxive template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.18
 ---------------------------------------------------------------------
 
+- `arxiv_article()` now supports header-include and bibstyle. (thanks, @eliocamp)
+
 - Update jss.cls to version 3.2 (#329).
 
 - Options can now be passed to `hyperref` packages using `header-includes` and `\PassOptionsToPackage` in the AEA template (thanks, @nurfatimaj, #334)
@@ -29,8 +31,6 @@ rticles 0.16
 - Fixed `ctex_article()` to correctly use the default Pandoc template as intended in the PR #307, which introduced the bug #322 (thanks, @baketbek @cderv #323).
 
 - The minimal version of **knitr** required is 1.30 now.
-
-- `arxiv_article()` now supports header-include and bibstyle. (thanks, @eliocamp)
 
 rticles 0.15
 ---------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@ rticles 0.16
 
 - The minimal version of **knitr** required is 1.30 now.
 
+- `arxiv_article()` now supports header-include and bibstyle. (thanks, @eliocamp)
+
 rticles 0.15
 ---------------------------------------------------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rticles 0.18
 ---------------------------------------------------------------------
 
-- `arxiv_article()` now supports header-include and bibstyle. (thanks, @eliocamp)
+- `arxiv_article()` now supports `header-includes` and `biblio-style` to use in the YAML header in order to customize its template. Default bibliography style is still _unsrt_ if not set as before. (thanks, @eliocamp, #356).
 
 - Update jss.cls to version 3.2 (#329).
 

--- a/inst/rmarkdown/templates/arxiv/resources/template.tex
+++ b/inst/rmarkdown/templates/arxiv/resources/template.tex
@@ -65,6 +65,11 @@ $if(csl-refs)$
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+
 \begin{document}
 \maketitle
 

--- a/inst/rmarkdown/templates/arxiv/resources/template.tex
+++ b/inst/rmarkdown/templates/arxiv/resources/template.tex
@@ -94,7 +94,7 @@ $endif$
 
 $body$
 
-\bibliographystyle{unsrt}
+\bibliographystyle{$if(bibstyle)$$bibstyle$$else$unsrt$endif$}
 \bibliography{$bibliography$}
 
 $for(include-after)$

--- a/inst/rmarkdown/templates/arxiv/resources/template.tex
+++ b/inst/rmarkdown/templates/arxiv/resources/template.tex
@@ -94,7 +94,7 @@ $endif$
 
 $body$
 
-\bibliographystyle{$if(bibstyle)$$bibstyle$$else$unsrt$endif$}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$unsrt$endif$}
 \bibliography{$bibliography$}
 
 $for(include-after)$

--- a/inst/rmarkdown/templates/arxiv/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/arxiv/skeleton/skeleton.Rmd
@@ -20,6 +20,7 @@ keywords:
   - bloo
   - these are optional and can be removed
 bibliography: references.bib
+bibstyle: unsrt
 output: 
   rticles::arxiv_article:
     keep_tex: true

--- a/inst/rmarkdown/templates/arxiv/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/arxiv/skeleton/skeleton.Rmd
@@ -20,7 +20,7 @@ keywords:
   - bloo
   - these are optional and can be removed
 bibliography: references.bib
-bibstyle: unsrt
+biblio-style: unsrt
 output: 
   rticles::arxiv_article:
     keep_tex: true


### PR DESCRIPTION
Related to #345
The arxive template didn't have the holy 

```
$for(header-includes)$
$header-includes$
$endfor$
```

it also had biblyographystyle hardcoded. 
