### PR TITLE
Uses biblio-style instead of bibstyle in springer_article

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 rticles 0.18
 ---------------------------------------------------------------------
 
+- `springer_article()` now uses the yaml variable biblio-style to set bibliogrphy style
+instead of bibstyle. (@eliocamp, #358)
+
 - Update jss.cls to version 3.2 (#329).
 
 - Options can now be passed to `hyperref` packages using `header-includes` and `\PassOptionsToPackage` in the AEA template (thanks, @nurfatimaj, #334)

--- a/inst/rmarkdown/templates/springer/resources/template.tex
+++ b/inst/rmarkdown/templates/springer/resources/template.tex
@@ -132,7 +132,8 @@ $endif$
 
 $body$
 
-\bibliographystyle{$if(biblio-style)$$biblio-style$$else$spbasic$endif$}
+
+\bibliographystyle{$if(biblio-style)$$biblio-style$$elseif(bibstyle)$$bibstyle$$else$spbasic$endif$}
 \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 
 \end{document}

--- a/inst/rmarkdown/templates/springer/resources/template.tex
+++ b/inst/rmarkdown/templates/springer/resources/template.tex
@@ -132,7 +132,7 @@ $endif$
 
 $body$
 
-\bibliographystyle{$if(bibstyle)$$bibstyle$$else$spbasic$endif$}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$spbasic$endif$}
 \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 
 \end{document}

--- a/inst/rmarkdown/templates/springer/resources/template.tex
+++ b/inst/rmarkdown/templates/springer/resources/template.tex
@@ -133,7 +133,7 @@ $endif$
 $body$
 
 
-\bibliographystyle{$if(biblio-style)$$biblio-style$$elseif(bibstyle)$$bibstyle$$else$spbasic$endif$}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$$if(bibstyle)$$bibstyle$$else$spbasic$endif$$endif$}
 \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 
 \end{document}

--- a/inst/rmarkdown/templates/springer/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/springer/skeleton/skeleton.Rmd
@@ -34,7 +34,7 @@ abstract: |
   The text of your abstract.  150 -- 250 words.
 
 bibliography: bibliography.bib
-bibstyle: spphys
+biblio-style: spphys
 # bibstyle options spbasic(default), spphys, spmpsci
 output: rticles::springer_article
 ---


### PR DESCRIPTION
Following on this comment
https://github.com/rstudio/rticles/pull/356#discussion_r544181296

This changes the variable name from bibstyle to biblio-style to match the default pandoc template for latex and other rticles templates. 