### PR TITLE
Copernicus template additional information on copyright statement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 rticles 0.19
 ---------------------------------------------------------------------
 - Update Copernicus Publications template to version 6.2 from 2021-01-15 (thanks, @RLumSK, #366)
-- The Copernicus template did show the copyright statement in the correct section; corrected. 
 
 rticles 0.18
 ---------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 rticles 0.19
 ---------------------------------------------------------------------
-- Update Copernicus Publications template to version 6.2 from 2021-01-15 (thanks, @RLumSK, #366)
+- Update Copernicus Publications template to version 6.2 from 2021-01-15 (thanks, @RLumSK, #366).
 
 rticles 0.18
 ---------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
 rticles 0.19
 ---------------------------------------------------------------------
-- Update Copernicus Publications template to version 6.2 from 2021-01-15. (thanks, @RLumSK, #366)
+- Update Copernicus Publications template to version 6.2 from 2021-01-15 (thanks, @RLumSK, #366)
+- The Copernicus template did show the copyright statement in the correct section; corrected. 
 
 rticles 0.18
 ---------------------------------------------------------------------
 
-- `springer_article()` now uses the yaml variable biblio-style to set bibliogrphy style
+- `springer_article()` now uses the yaml variable biblio-style to set bibliography style
 instead of bibstyle. (@eliocamp, #358)
 
 - Fixes a bug when rendering `arxiv_article()` with recent version of TeX Live by adding `\usepackage{lmodern}` to the template. (#thanks, @slemonide, #343)

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -171,14 +171,11 @@ $abstract$
 \end{abstract}
 $endif$
 
+$body$
 
 $if(copyrightstatement)$
 \copyrightstatement{$copyrightstatement$}
 $endif$
-
-
-$body$
-
 
 $if(availability.code)$
 \codeavailability{$availability.code$} %% use this section when having only software code available

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -171,11 +171,13 @@ $abstract$
 \end{abstract}
 $endif$
 
-$body$
 
 $if(copyrightstatement)$
 \copyrightstatement{$copyrightstatement$}
 $endif$
+
+
+$body$
 
 $if(availability.code)$
 \codeavailability{$availability.code$} %% use this section when having only software code available

--- a/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
@@ -48,11 +48,13 @@ competinginterests: |
   The authors declare no competing interests.
 # OPTIONAL:
 algorithms: true
-# See https://publications.copernicus.org/for_authors/licence_and_copyright.html, normally used for transferring the copyright, if needed.
+# See https://publications.copernicus.org/for_authors/licence_and_copyright.html, normally used for transferring the copyright, if needed. 
+# Note: additional copyright statements for affiliated software or data need to be placed in the data availability section. 
 copyrightstatement: |
-  The author's copyright for this publication is transferred to institution/company.
+  The author's copyright for this publication is transferred to institution/company. 
 ### The following commands are for the statements about the availability of data sets and/or software code corresponding to the manuscript.
 ### It is strongly recommended to make use of these sections in case data sets and/or software code have been part of your research the article is based on.
+### Note: unless stated otherwise, software and data affiliated with the manuscript are assumed to be published under the same licence as the article (currently Creative Commons 4.0)
 availability:
   #code: |
   #  use this to add a statement when having only software code available


### PR DESCRIPTION
## Scope 
This pull request addresses a minor issue in the Copernicus template LaTeX file, placing the copyright statement further down.

## Background
I am currently co-authoring a manuscript for a Copernicus journal. Our manuscript was accepted for a public discussion. However, it bounced back to us during the file validation step. The email we received from the Copernicus office said: 

> I would like to inform you that the copyright statement should appear in the data/code availability section or wherever the data is mentioned in the preprint. 

## Modified files
Hence, I modified the `template.tex` accordingly and tested it. It seems fine now. Still, @nuest perhaps you want to double-check the amendment since you created the template? 

Modified files:

- `template.tex`
- `NEWS.md` (including a minor typo correction in an old news line)

- [X] Update NEWS.
