### PR TITLE
Copernicus template update - fixes syntax highlight problem

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rticles
 Type: Package
 Title: Article Formats for R Markdown
-Version: 0.19.2
+Version: 0.19.3
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 rticles 0.20
 ---------------------------------------------------------------------
+- Fixes a problem in the Copernicus Publications template that causes a manuscript to bounce back to the author during the typesetting step. This was triggered by the inclusion (unknown to the author) of non-supported LaTeX packages and commands if programming code was part of the manuscript using the standard 'rmarkdown' code support. Additionally, the template gained support for the `highlight` parameter of `rmarkdown::pdf_document` to enable or disable syntax 
+highlight (disabled by default, as required by Copernicus)
 
 
 rticles 0.19

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 rticles 0.20
 ---------------------------------------------------------------------
 - Fixes a problem in the Copernicus Publications template that causes a manuscript to bounce back to the author during the typesetting step. This was triggered by the inclusion (unknown to the author) of non-supported LaTeX packages and commands if programming code was part of the manuscript using the standard 'rmarkdown' code support. Additionally, the template gained support for the `highlight` parameter of `rmarkdown::pdf_document` to enable or disable syntax 
-highlight (disabled by default, as required by Copernicus)
+highlight (disabled by default, as required by Copernicus). **Note: this is breaking change.** In order to see the previous
+syntax highlighting, please set `highlight: "default"` in the YAML header.
 
 
 rticles 0.19

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,14 @@
 rticles 0.20
 ---------------------------------------------------------------------
-- Fixes a problem in the Copernicus Publications template that causes a manuscript to bounce back to the author during the typesetting step. This was triggered by the inclusion (unknown to the author) of non-supported LaTeX packages and commands if programming code was part of the manuscript using the standard 'rmarkdown' code support. Additionally, the template gained support for the `highlight` parameter of `rmarkdown::pdf_document` to enable or disable syntax 
-highlight (disabled by default, as required by Copernicus). **Note: this is breaking change.** In order to see the previous
-syntax highlighting, please set `highlight: "default"` in the YAML header.
+
+- Update Copernicus Publications template to comply with editor's guidelines following a manuscript bounce back during the typesetting step. Copernicus does not allow to add any `\usepackage` command as they all are included in `copernicus.cls` for supported LaTeX packages. **This is leading to breaking changes with existing template - please follow the advice below**.
+  - `algorithms: true` cannot be used anymore and as no more effect. `\usepackage{algorithmic}` and `\usepackage{algorithm}` has been removed from the template as the command are already done in `copernicus.cls`. Please, make sure `algorithms` and `algorithmcx` are installed.  
+  - Additionally, the template gained support for the `highlight` parameter of `rmarkdown::pdf_document` to enable or disable syntax highlighting with Pandoc. To comply with the above guideline by Copernicus, it is disabled by default (`highlight: NULL`) to prevent Pandoc adding any more packages required for its highlighting. Syntax highlighting can be reactivating by using `highlight: "default"` in the YAML header as this can be desirable before submitting for typesetting. (thanks, @RLumSK, @nuest, #391).
 
 
 rticles 0.19
 ---------------------------------------------------------------------
+
 - Update Copernicus Publications template to version 6.2 from 2021-01-15 (thanks, @RLumSK, #366).
 
 - Add article template `pihph_article()` for the *Papers in Historical Phonology* (PiHPh) (thanks, @stefanocoretta, #362).

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -57,7 +57,7 @@ copernicus_article <- function(
   )
 ) {
   if("extra_dependencies" %in% names(list(...)))
-    stop("Copernicus does not support additional LaTeX packages and options!
+    warning("Copernicus does not support additional LaTeX packages and options!
           >> Please remove 'extra_dependencies' from your YAML header!",
          call. = FALSE)
 

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -48,14 +48,14 @@
 #' }
 #' @export
 copernicus_article <- function(
-  ..., keep_tex = TRUE, citation_package = "natbib", md_extensions = c(
+  ..., keep_tex = TRUE, highlight = NULL, citation_package = "natbib", md_extensions = c(
     "-autolink_bare_uris", # disables automatic links, needed for plain email in \correspondence
     "-auto_identifiers"    # disables \hypertarget commands
   )
 ) {
   pdf_document_format(
     "copernicus", citation_package = citation_package,
-    keep_tex = keep_tex, md_extensions = md_extensions, ...
+    keep_tex = keep_tex, highlight = highlight, md_extensions = md_extensions, ...
   )
 }
 

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -12,7 +12,7 @@
 #'
 #' An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' \strong{Version:} Based on Copernicus_package.zip in the version 6.2, 15 January 2021, using \code{copernicus.cls} in version 9.25.
+#' \strong{Version:} Based on \code{copernicus_package.zip} in the version 6.2, 15 January 2021, using \code{copernicus.cls} in version 9.25.
 #'
 #' \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -12,13 +12,13 @@
 #'
 #' An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' \strong{Version:} Based on copernicus_package.zip in the version 5.3, 18 February 2019, using \code{copernicus.cls} in version 8.82.
+#' \strong{Version:} Based on Copernicus_package.zip in the version 6.2, 15 January 2021, using \code{copernicus.cls} in version 9.25.
 #'
-#' \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the copernicus article template.
+#' \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'
 #' \strong{Important note:} The online guidelines by Copernicus are the official resource.
 #' Copernicus is not responsible for the community contributions made to support the template in this package.
-#' Copenicus converts all typeset TeX files into XML, the expressions and markups have to be highly standardized.
+#' Copernicus converts all typeset TeX files into XML, the expressions and markups have to be highly standardized.
 #' Therefore, please keep the following in mind:
 #'
 #' \itemize{
@@ -26,7 +26,7 @@
 #'   \item Please use only commands in which words, numbers, etc. are within braces (e.g. \code{\\textrm{TEXT}} instead of \code{{\\rm TEXT}}).
 #'   \item For algorithms, please use the syntax given in template.tex or provide your algorithm as a figure.
 #'   \item Please do not define new commands.
-#'   \item The most commonly used packages (\code{\\usepackage{}}) are integrated in the copernicus.cls. Some other packages often used by the community are defined in template.tex. Please do not insert additional ones in your *.tex file.
+#'   \item The most commonly used packages (\code{\\usepackage{}}) are integrated in the \code{copernicus.cls}. Some other packages often used by the community are defined in template.tex. Please do not insert additional ones in your *.tex file.
 #'   \item Spaces in labels (\code{\\label{}}) are not allowed; please make sure that no label name is assigned more than once.
 #'   \item Please do not use \code{\\paragraph{}}; only \code{\\subsubsection{}} is allowed.
 #'   \item It is not possible to add tables in colour.

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -56,10 +56,12 @@ copernicus_article <- function(
     "-auto_identifiers"    # disables \hypertarget commands
   )
 ) {
-  if("extra_dependencies" %in% names(list(...)))
-    warning("Copernicus does not support additional LaTeX packages and options!
+  if ("extra_dependencies" %in% names(list(...)))
+    warning(
+      "Copernicus does not support additional LaTeX packages and options!
           >> Please remove 'extra_dependencies' from your YAML header!",
-         call. = FALSE)
+      call. = FALSE
+    )
 
   pdf_document_format(
     "copernicus", citation_package = citation_package,

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -26,7 +26,9 @@
 #'   \item Please use only commands in which words, numbers, etc. are within braces (e.g. \code{\\textrm{TEXT}} instead of \code{{\\rm TEXT}}).
 #'   \item For algorithms, please use the syntax given in template.tex or provide your algorithm as a figure.
 #'   \item Please do not define new commands.
-#'   \item The most commonly used packages (\code{\\usepackage{}}) are integrated in the \code{copernicus.cls}. Some other packages often used by the community are defined in template.tex. Please do not insert additional ones in your *.tex file.
+#'   \item Supported packages (\code{\\usepackage{}}) are already integrated in the \code{copernicus.cls}.  Please do not insert additional ones in your \code{*.tex} file.
+#'   \item If you opt for syntax highlighting for your preprint or other reasons, please do not forget to use
+#'    \code{highlight = NULL} for your final file upload once your manuscript was accepted for publication.
 #'   \item Spaces in labels (\code{\\label{}}) are not allowed; please make sure that no label name is assigned more than once.
 #'   \item Please do not use \code{\\paragraph{}}; only \code{\\subsubsection{}} is allowed.
 #'   \item It is not possible to add tables in colour.

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -3,7 +3,8 @@
 #' Format for creating submissions to Copernicus journals.
 #'
 #' @inheritParams rmarkdown::pdf_document
-#' @param ... Additional arguments to \code{rmarkdown::pdf_document()}.
+#' @param ... Additional arguments to \code{rmarkdown::pdf_document()}. \bold{Note}: \code{extra_dependencies} are not
+#' allowed as Copernicus does not support additional packages included via \code{\\usepackage{}}.
 #' @param journal_name A regular expression to filter the by the journal name, see \code{pattern} in \code{\link[base]{grep}}; defaults to \code{*}.
 #'
 #' @return An R Markdown output format.
@@ -55,6 +56,11 @@ copernicus_article <- function(
     "-auto_identifiers"    # disables \hypertarget commands
   )
 ) {
+  if("extra_dependencies" %in% names(list(...)))
+    stop("Copernicus does not support additional LaTeX packages and options!
+          >> Please remove 'extra_dependencies' from your YAML header!",
+         call. = FALSE)
+
   pdf_document_format(
     "copernicus", citation_package = citation_package,
     keep_tex = keep_tex, highlight = highlight, md_extensions = md_extensions, ...

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -111,11 +111,6 @@ $endif$
 %$header-includes$
 %$endfor$
 
-$if(algorithms)$
-\usepackage{algorithmic}
-\usepackage{algorithm}
-$endif$
-
 $if(highlighting-macros)$
 $highlighting-macros$
 $endif$

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -62,8 +62,9 @@
 % Web Ecology (we)
 % Wind Energy Science (wes)
 
-
-%% \usepackage commands included in the copernicus.cls:
+%% Please DO NOT add additional packages or LaTeX commands to the template. They
+%% are not supported by Coperncius. LaTeX packages already
+%% included in the copernicus.cls are:
 %\usepackage[german, english]{babel}
 %\usepackage{tabularx}
 %\usepackage{cancel}

--- a/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
@@ -307,9 +307,13 @@ $$
 
 ## ALGORITHM/PROGRAMMING CODE
 
-If you want to use algorithms or programming code, you can either use the default 'rmarkdown' functionality, which includes the
-code in \LaTeX{} using the `verbatim` environment or using the \LaTeX{} packages `algorithms` and `algorithmicx`. Both need 
-to be available through your preferred \LaTeX{} distribution. 
+If you want to use algorithms, you need to make sure yourself that the \LaTeX packages `algorithms` and `algorithmicx` are installed so that `algorithm.sty` respectively `algorithmic.sty` can be loaded by the Copernicus template. Both need to be available through your preferred \LaTeX{} distribution. With TinyTeX (or TeX Live), you can do so by running `tinytex::tlmgr_install(c("algorithms", "algorithmicx"))`
+
+```{r, echo = FALSE, eval = tinytex::is_tinytex()}
+tinytex::tlmgr_install(c("algorithms", "algorithmicx"))
+```
+
+Copernicus staff will no accept any additional packages from your LaTeX source code, so please stick to these two acceptable packages. They are needed to use the example below
 
 \begin{algorithm}
 \caption{Algorithm Caption}

--- a/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
@@ -85,7 +85,9 @@ appendix: |
   
   Please add `\clearpage` between each table and/or figure. Further guidelines on figures and tables can be found below.
 output:
-  rticles::copernicus_article: default
+  rticles::copernicus_article: 
+    highlight: NULL
+    keep_tex: true
   bookdown::pdf_book:
     base_format: rticles::copernicus_article # for using bookdown features like \@ref()
 ---
@@ -93,7 +95,7 @@ output:
 \introduction[Introduction]
 
 Introduction text goes here.
-You can change the name of the section if neccessary using `\introduction[modified heading]`.
+You can change the name of the section if necessary using `\introduction[modified heading]`.
 
 The following settings can or must be configured in the header of this file and are bespoke for Copernicus manuscripts:
 
@@ -288,10 +290,13 @@ x & y & z\\
 \end{matrix}
 $$
 
-## ALGORITHM
+## ALGORITHM/PROGRAMMING CODE
 
-If you want to use algorithms, you can either enable the required packages in the header (the default, see `algorithms: true`), or make sure yourself that the \LaTeX packages `algorithms` and `algorithmicx` are installed so that `algorithm.sty` respectively `algorithmic.sty` can be loaded by the Copernicus template.
-Copernicus staff will remove all undesirable packages from your LaTeX source code, so please stick to using the header option, which only adds the two acceptable packages.
+If you want to use algorithms or programming code, you can either use the default 'rmarkdown' functionality, which includes the
+code in \LaTeX{} using the `verbatim` environment or using the \LaTeX{} packages `algorithms` and `algorithmicx`. Both need 
+to be available through your preferred \LaTeX{} distribution. 
+
+**Please note:** Copernicus does not support additional \LaTeX{} packages or new \LaTeX{} commands. This extends to syntax highlighting of source code. Therefore this template sets the parameter `highlights` in the YAML header to `NULL`. However, it might be desirable to have syntax highlight available in preprints or for others reasons. Please see `?rmarkdown::pdf_document` for available options.
 
 \begin{algorithm}
 \caption{Algorithm Caption}

--- a/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
@@ -119,8 +119,23 @@ The following settings can or must be configured in the header of this file and 
 
 See the defaults and examples from the skeleton and the official Copernicus documentation for details.
 
-**Important**: Always double-check with the official manuscript preparation guidelines at [https://publications.copernicus.org/for_authors/manuscript_preparation.html](https://publications.copernicus.org/for_authors/manuscript_preparation.html), especially the sections "Technical instructions for LaTeX" and "Manuscript composition".
-Please contact Daniel Nüst, `daniel.nuest@uni-muenster.de`, with any problems.
+**Please note:** Per [their
+guidelines](https://publications.copernicus.org/for_authors/manuscript_preparation.html),
+Copernicus does not support additional \LaTeX{} packages or new \LaTeX{}
+commands than those defined in their `.cls` file. This means that you cannot add any extra dependencies and a warning will be thrown if so.  
+This extends to syntax highlighting of source code. Therefore this template sets
+the parameter `highlight` in the YAML header to `NULL` to deactivate Pandoc
+syntax highlighter. This prevent addition of external packages for highlighting
+inserted by Pandoc. However, it might be desirable to have syntax highlight
+available in preprints or for others reasons. Please see
+`?rmarkdown::pdf_document` for available options to activate highlighting.
+
+**Important**: Always double-check with the official manuscript preparation
+guidelines at
+[https://publications.copernicus.org/for_authors/manuscript_preparation.html](https://publications.copernicus.org/for_authors/manuscript_preparation.html),
+especially the sections "Technical instructions for LaTeX" and "Manuscript
+composition". Please contact Daniel Nüst, `daniel.nuest@uni-muenster.de`, with
+any problems.
 
 # Content section one
 
@@ -295,8 +310,6 @@ $$
 If you want to use algorithms or programming code, you can either use the default 'rmarkdown' functionality, which includes the
 code in \LaTeX{} using the `verbatim` environment or using the \LaTeX{} packages `algorithms` and `algorithmicx`. Both need 
 to be available through your preferred \LaTeX{} distribution. 
-
-**Please note:** Copernicus does not support additional \LaTeX{} packages or new \LaTeX{} commands. This extends to syntax highlighting of source code. Therefore this template sets the parameter `highlights` in the YAML header to `NULL`. However, it might be desirable to have syntax highlight available in preprints or for others reasons. Please see `?rmarkdown::pdf_document` for available options.
 
 \begin{algorithm}
 \caption{Algorithm Caption}

--- a/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/copernicus/skeleton/skeleton.Rmd
@@ -46,8 +46,6 @@ running:
 # This section is mandatory even if you declare that no competing interests are present.
 competinginterests: |
   The authors declare no competing interests.
-# OPTIONAL:
-algorithms: true
 # See https://publications.copernicus.org/for_authors/licence_and_copyright.html, normally used for transferring the copyright, if needed. 
 # Note: additional copyright statements for affiliated software or data need to be placed in the data availability section. 
 copyrightstatement: |

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -8,6 +8,7 @@
 copernicus_article(
   ...,
   keep_tex = TRUE,
+  highlight = NULL,
   citation_package = "natbib",
   md_extensions = c("-autolink_bare_uris", "-auto_identifiers")
 )
@@ -18,6 +19,10 @@ copernicus_journal_abbreviations(journal_name = "*")
 \item{...}{Additional arguments to \code{rmarkdown::pdf_document()}.}
 
 \item{keep_tex}{Keep the intermediate tex file used in the conversion to PDF}
+
+\item{highlight}{Syntax highlighting style. Supported styles include
+"default", "tango", "pygments", "kate", "monochrome", "espresso",
+"zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
 
 \item{citation_package}{The LaTeX package to process citations, \code{natbib}
 or \code{biblatex}. Use \code{default} if neither package is to be used,
@@ -42,13 +47,13 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on copernicus_package.zip in the version 5.3, 18 February 2019, using \code{copernicus.cls} in version 8.82.
+\strong{Version:} Based on Copernicus_package.zip in the version 6.2, 15 January 2021, using \code{copernicus.cls} in version 9.25.
 
-\strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the copernicus article template.
+\strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 
 \strong{Important note:} The online guidelines by Copernicus are the official resource.
 Copernicus is not responsible for the community contributions made to support the template in this package.
-Copenicus converts all typeset TeX files into XML, the expressions and markups have to be highly standardized.
+Copernicus converts all typeset TeX files into XML, the expressions and markups have to be highly standardized.
 Therefore, please keep the following in mind:
 
 \itemize{
@@ -56,7 +61,7 @@ Therefore, please keep the following in mind:
   \item Please use only commands in which words, numbers, etc. are within braces (e.g. \code{\\textrm{TEXT}} instead of \code{{\\rm TEXT}}).
   \item For algorithms, please use the syntax given in template.tex or provide your algorithm as a figure.
   \item Please do not define new commands.
-  \item The most commonly used packages (\code{\\usepackage{}}) are integrated in the copernicus.cls. Some other packages often used by the community are defined in template.tex. Please do not insert additional ones in your *.tex file.
+  \item The most commonly used packages (\code{\\usepackage{}}) are integrated in the \code{copernicus.cls}. Some other packages often used by the community are defined in template.tex. Please do not insert additional ones in your *.tex file.
   \item Spaces in labels (\code{\\label{}}) are not allowed; please make sure that no label name is assigned more than once.
   \item Please do not use \code{\\paragraph{}}; only \code{\\subsubsection{}} is allowed.
   \item It is not possible to add tables in colour.

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -47,7 +47,7 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on Copernicus_package.zip in the version 6.2, 15 January 2021, using \code{copernicus.cls} in version 9.25.
+\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.2, 15 January 2021, using \code{copernicus.cls} in version 9.25.
 
 \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -61,7 +61,9 @@ Therefore, please keep the following in mind:
   \item Please use only commands in which words, numbers, etc. are within braces (e.g. \code{\\textrm{TEXT}} instead of \code{{\\rm TEXT}}).
   \item For algorithms, please use the syntax given in template.tex or provide your algorithm as a figure.
   \item Please do not define new commands.
-  \item The most commonly used packages (\code{\\usepackage{}}) are integrated in the \code{copernicus.cls}. Some other packages often used by the community are defined in template.tex. Please do not insert additional ones in your *.tex file.
+  \item Supported packages (\code{\\usepackage{}}) are already integrated in the \code{copernicus.cls}.  Please do not insert additional ones in your \code{*.tex} file.
+  \item If you opt for syntax highlighting for your preprint or other reasons, please do not forget to use
+   \code{highlight = NULL} for your final file upload once your manuscript was accepted for publication.
   \item Spaces in labels (\code{\\label{}}) are not allowed; please make sure that no label name is assigned more than once.
   \item Please do not use \code{\\paragraph{}}; only \code{\\subsubsection{}} is allowed.
   \item It is not possible to add tables in colour.

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -16,7 +16,8 @@ copernicus_article(
 copernicus_journal_abbreviations(journal_name = "*")
 }
 \arguments{
-\item{...}{Additional arguments to \code{rmarkdown::pdf_document()}.}
+\item{...}{Additional arguments to \code{rmarkdown::pdf_document()}. \bold{Note}: \code{extra_dependencies} are not
+allowed as Copernicus does not support additional packages included via \code{\\usepackage{}}.}
 
 \item{keep_tex}{Keep the intermediate tex file used in the conversion to PDF}
 


### PR DESCRIPTION
Yet another update for the Copernicus Publication template after the `*.tex` produced by 'rticles' bounced back from the journal's office telling that additional LaTeX packages and commands are not supported. This was caused by the default syntax highlight enabled in `rmarkdown::pdf_document()`, which uses additional LaTeX commands.

To ensure that this update aligns with the publisher guidelines, I first discussed with @nuest via email and then contacted the journal's office before making this update (@nuest was in CC). 

Hence, this update ensures that the publisher will accept the `*.tex` produced by the templates without requiring further manual changes by the authors.  

**More details**

* The template now supports the `highlight` parameter of `rmarkdown::pdf_document()`. The default is set to `NULL`, which lets Pandoc set programming code in the verbatim environment. This solution is supported by the publisher, who currently uses the LaTeX packages `algorithms` and `algorithmicx`. The author still has the option to use these two LaTeX packages.
* The `*.Rmd` template and the `*.tex` template were modified accordingly.  
* The options `highlights` and `keep_tex` are now explicitly mentioned in the YAML header

- [x] Update Rd and namespace (could be done by `devtools::document()`).

- [x] Update NEWS.

@nuest, I hope I did everything correctly. However, would you mind looking over it another time? 
