### PR TITLE
Opt-out bookdown environment definition for lipic article

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.20
 ---------------------------------------------------------------------
 
+- `lipics_article()` now works with `bookdown::pdf_book()` as their is no more conflict in theorem environment definition. This requires **bookdown** 0.23 or higher (#392).
+
 - Update Copernicus Publications template to comply with editor's guidelines following a manuscript bounce back during the typesetting step. Copernicus does not allow to add any `\usepackage` command as they all are included in `copernicus.cls` for supported LaTeX packages. **This is leading to breaking changes with existing template - please follow the advice below**.
   - `algorithms: true` cannot be used anymore and as no more effect. `\usepackage{algorithmic}` and `\usepackage{algorithm}` has been removed from the template as the command are already done in `copernicus.cls`. Please, make sure `algorithms` and `algorithmcx` are installed.  
   - Additionally, the template gained support for the `highlight` parameter of `rmarkdown::pdf_document` to enable or disable syntax highlighting with Pandoc. To comply with the above guideline by Copernicus, it is disabled by default (`highlight: NULL`) to prevent Pandoc adding any more packages required for its highlighting. Syntax highlighting can be reactivating by using `highlight: "default"` in the YAML header as this can be desirable before submitting for typesetting. (thanks, @RLumSK, @nuest, #391).

--- a/R/article.R
+++ b/R/article.R
@@ -252,23 +252,11 @@ lipics_article <- function(
 ) {
   # quick dev shortcut for Ubuntu: click "Install and restart" then run:
   # unlink("MyArticle/", recursive = TRUE); rmarkdown::draft("MyArticle.Rmd", template = "lipics", package = "rticles", edit = FALSE); rmarkdown::render("MyArticle/MyArticle.Rmd"); system(paste0("xdg-open ", here::here("MyArticle", "MyArticle.pdf")))
-  base <- pdf_document_format(
+  pdf_document_format(
     "lipics", latex_engine = latex_engine,
     citation_package = citation_package, keep_tex = keep_tex,
     md_extensions = md_extensions, ...
   )
-
-  # we deactivate bookdown addition of environment definitions in preamble
-  # to avoid conflict as lipics already defines some
-  opts <- options(bookdown.theorem.preamble = FALSE)
-  on_exit <- function() options(opts)
-
-  base_on_exit <- base$on_exit
-  base$on_exit <- function() {
-    if (is.function(base_on_exit)) base_on_exit()
-    on_exit()
-  }
-  base
 }
 
 #' @section \code{mdpi_article}: Format for creating submissions to

--- a/R/article.R
+++ b/R/article.R
@@ -252,11 +252,23 @@ lipics_article <- function(
 ) {
   # quick dev shortcut for Ubuntu: click "Install and restart" then run:
   # unlink("MyArticle/", recursive = TRUE); rmarkdown::draft("MyArticle.Rmd", template = "lipics", package = "rticles", edit = FALSE); rmarkdown::render("MyArticle/MyArticle.Rmd"); system(paste0("xdg-open ", here::here("MyArticle", "MyArticle.pdf")))
-  pdf_document_format(
+  base <- pdf_document_format(
     "lipics", latex_engine = latex_engine,
     citation_package = citation_package, keep_tex = keep_tex,
     md_extensions = md_extensions, ...
   )
+
+  # we deactivate bookdown addition of environment definitions in preamble
+  # to avoid conflict as lipics already defines some
+  opts <- options(bookdown.theorem.preamble = FALSE)
+  on_exit <- function() options(opts)
+
+  base_on_exit <- base$on_exit
+  base$on_exit <- function() {
+    if (is.function(base_on_exit)) base_on_exit()
+    on_exit()
+  }
+  base
 }
 
 #' @section \code{mdpi_article}: Format for creating submissions to

--- a/inst/rmarkdown/templates/lipics/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/lipics/skeleton/skeleton.Rmd
@@ -173,7 +173,15 @@ appendix: |
   List of different predefined enumeration styles:
 output:
   rticles::lipics_article: default
+  # To use with bookdown feature
+  bookdown::pdf_book:
+    base_format: rticles::lipics_article
 ---
+
+```{r setup, include = FALSE}
+# deactivate addition of preamble when this format is used with bookdown
+options(bookdown.theorem.preamble = FALSE)
+```
 
 # Typesetting instructions -- Summary
 


### PR DESCRIPTION
This fixes #392 (cc @nuest)

This can now be used in YAML 
```
output:
  bookdown::pdf_book:
    base_format: rticles::lipics_article
```
and it will no more error with 
```
! LaTeX Error: Command \theorem already defined.
               Or name \end... illegal, see p.192 of the manual.
``` 

This change set an option for opting out the addition by **bookdown** of some definition. This requires **bookdown** 0.23 (currently dev version) to work

```r
remotes::install_github("rstudio/bookdown")
```

@yihui 
 * is this how you would do it ? I used the `on_exit` argument to be sure to reset the options after `render()`
 * I did not set a requirement for **bookdown**  up in DESCRIPTION as it is in suggest, should I ? 
 * This requires **bookdown** 0.23, should we merge in **rticles** only when it is release ? I added a mention in NEWS about the requirement for this.