### PR TITLE
Expose biblio-style in elsarticle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rticles 0.20
 ---------------------------------------------------------------------
 
+- `elsevier_article()` now supports `biblio-style` Pandoc's variable to set the natbib bibliography style in YAML header (thanks, @gregmacfarlane, #402).
+
 - Fix an issue with `rjournal_article()`. The `.R` file in output is now correctly overwritten on a new render if it existed from a previous render (thanks, @apreshill, #394).
 
 - Update Copernicus Publications template to comply with editor's guidelines following a manuscript bounce back during the typesetting step. Copernicus does not allow to add any `\usepackage` command as they all are included in `copernicus.cls` for supported LaTeX packages. **This is leading to breaking changes with existing template - please follow the advice below**.

--- a/inst/rmarkdown/templates/elsevier/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier/resources/template.tex
@@ -57,11 +57,7 @@ $if(geometry)$
 $endif$
 $if(natbib)$
 \usepackage{natbib}
-$if(biblio-style)$
-\bibliographystyle{$biblio-style$}
-$else$
-\bibliographystyle{plainnat}
-$endif$
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $else$
 \bibliographystyle{elsarticle-harv}
 $endif$
@@ -210,5 +206,4 @@ $include-after$
 
 $endfor$
 \end{document}
-
 

--- a/inst/rmarkdown/templates/elsevier/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier/resources/template.tex
@@ -58,6 +58,8 @@ $endif$
 $if(natbib)$
 \usepackage{natbib}
 \bibliographystyle{plainnat}
+$if(biblio-style)$
+\bibliographystyle{$biblio-style$
 $else$
 \bibliographystyle{elsarticle-harv}
 $endif$

--- a/inst/rmarkdown/templates/elsevier/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier/resources/template.tex
@@ -57,9 +57,11 @@ $if(geometry)$
 $endif$
 $if(natbib)$
 \usepackage{natbib}
-\bibliographystyle{plainnat}
 $if(biblio-style)$
-\bibliographystyle{$biblio-style$
+\bibliographystyle{$biblio-style$}
+$else$
+\bibliographystyle{plainnat}
+$endif$
 $else$
 \bibliographystyle{elsarticle-harv}
 $endif$


### PR DESCRIPTION
This is a minor commit that exposes the bookdown `biblio-style` argument to the `elsarticle` LaTeX template when using natbib.