### PR TITLE
changes reference location in Frontiers template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rticles
 Type: Package
 Title: Article Formats for R Markdown
-Version: 0.20.2
+Version: 0.20.3
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rticles 0.21
 ---------------------------------------------------------------------
 
+- Add the fenced div with id `#refs` in `frontier_article()` skeleton to place the reference section in the correct expected place (thanks, @graysonwhite, #423).
 - `bioinformatics_article()` has no more trailing comma after last author (thanks, @stephenturner, #413).
 - `bioinformatics_article()` now separates `manuscript_type` (e.g., Applications note, Original article) and `subject_section` (e.g. Genome analysis, Phylogenetics) in template and skeleton (thanks, @stephenturner, #415)
 

--- a/inst/rmarkdown/templates/frontiers/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/frontiers/skeleton/skeleton.Rmd
@@ -156,11 +156,10 @@ LaTeX folder
 
 # References
 
-A reference list should be automatically created here. However it won't. Pandoc 
-will place the list of references at the end of the document instead. There are 
-no convenient solution for now to force Pandoc to do otherwise. The easiest way 
-to get around this problem is to edit the LaTeX file created by Pandoc before 
-compiling it again using the traditional LaTeX commands.
+The below command places the reference list in this location, rather than adding them at the bottom of the article.
+
+::: {#refs}
+:::
 
 # Figures {-}
 

--- a/inst/rmarkdown/templates/frontiers/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/frontiers/skeleton/skeleton.Rmd
@@ -156,7 +156,8 @@ LaTeX folder
 
 # References
 
-The below command places the reference list in this location, rather than adding them at the bottom of the article.
+A Frontier article expect the reference list to be included in this section.
+To make that happens, the below syntax can be used. This [feature is from Pandoc citeproc](https://pandoc.org/MANUAL.html#placement-of-the-bibliography) which is used with `frontier_article()` to handle the bibliography
 
 ::: {#refs}
 :::


### PR DESCRIPTION
Hi there, love the package. I have been using it to typeset an article for Frontiers, and found a solution to moving the references to under the "References" header in Rmarkdown rather than at the end of the document. The solution was found from Andrew Morris' answer to [this stackoverflow](https://stackoverflow.com/questions/28815781/how-to-move-the-bibliography-in-markdown-pandoc) question. Hope this helps!