### PR TITLE
Update Copernicus to v6.4 and add missing Copernicus journal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rticles 0.22
 
-- Update Copernicus Publications template to version 6.4 from 2021-08-16
+- Update Copernicus Publications template to version 6.4 from 2021-08-16 (thanks, @RLumSK, #446).
  
 # rticles 0.21
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # rticles 0.22
 
-
+- Update Copernicus Publications template to version 6.4 from 2021-08-16
+ 
 # rticles 0.21
 
 ## NEW FEATURES

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -13,7 +13,7 @@
 #'
 #' An number of required and optional manuscript sections, e.g. `acknowledgements`, `competinginterests`, or `authorcontribution`, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' **Version:** Based on `copernicus_package.zip` in the version 6.3, 8 July 2021, using `copernicus.cls` in version 9.32, 7 July 2021.
+#' **Version:** Based on `copernicus_package.zip` in the version 6.4, 8th August 2021, using `copernicus.cls` in version 9.32, 7 July 2021.
 #'
 #' **Copernicus journal abbreviations:** You can use the function `copernicus_journal_abbreviations()` to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'
@@ -77,18 +77,17 @@ copernicus_journals <- list(
   "Advances in Statistical Climatology, Meteorology and Oceanography" = "ascmo",
   "Annales Geophysicae" = "angeo",
   "Archives Animal Breeding" = "aab",
-  "ASTRA Proceedings" = "ap",
   "Atmospheric Chemistry and Physics" = "acp",
   "Atmospheric Measurement Techniques" = "amt",
   "Biogeosciences" = "bg",
   "Climate of the Past" = "cp",
   "DEUQUA Special Publications" = "deuquasp",
   "Drinking Water Engineering and Science" = "dwes",
-  "European Journal of Mineralogy" = "ejm",
   "Earth Surface Dynamics" = "esurf",
   "Earth System Dynamics" = "esd",
   "Earth System Science Data" = "essd",
   "E&G Quaternary Science Journal" = "egqsj",
+  "European Journal of Mineralogy" = "ejm",
   "Fossil Record" = "fr",
   "Geochronology" = "gchron",
   "Geographica Helvetica" = "gh",
@@ -107,12 +106,14 @@ copernicus_journals <- list(
   "Ocean Science" = "os",
   "Primate Biology" = "pb",
   "Proceedings of the International Association of Hydrological Sciences" = "piahs",
+  "Safety of Nuclear Waste Disposal" = "sand",
   "Scientific Drilling" = "sd",
   "SOIL" = "soil",
   "Solid Earth" = "se",
   "The Cryosphere" = "tc",
   "Web Ecology" = "we",
   "Weather and Climate Dynamics" = "wcd",
+  "Web Ecology" = "we",
   "Wind Energy Science" = "wes"
 )
 

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_4.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_4.txt
@@ -1,7 +1,7 @@
-File: README_copernicus_package_6_3.txt
+File: README_copernicus_package_6_4.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 6.3, 8 July 2021
+copernicus_package.zip in the version 6.4, 16 August 2021
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -16,7 +16,7 @@ URL:   	https://publications.copernicus.org
 
 Content:
 - copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.32, 7 July 2021
-- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 8 July 2021
+- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 16 August 2021
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.3, January 2021 
 - pdfscreencop.sty / pdfscreen.sty
 - template.tex: A LaTeX template in journal style.

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -16,14 +16,12 @@
 
 %% Journal abbreviations (please use the same for preprints and final revised papers)
 
-
 % Advances in Geosciences (adgeo)
 % Advances in Radio Science (ars)
 % Advances in Science and Research (asr)
 % Advances in Statistical Climatology, Meteorology and Oceanography (ascmo)
 % Annales Geophysicae (angeo)
 % Archives Animal Breeding (aab)
-% ASTRA Proceedings (ap)
 % Atmospheric Chemistry and Physics (acp)
 % Atmospheric Measurement Techniques (amt)
 % Biogeosciences (bg)
@@ -54,6 +52,7 @@
 % Polarforschung - Journal of the German Society for Polar Research (polf)
 % Primate Biology (pb)
 % Proceedings of the International Association of Hydrological Sciences (piahs)
+% Safety of Nuclear Waste Disposal (sand)
 % Scientific Drilling (sd)
 % SOIL (soil)
 % Solid Earth (se)

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
@@ -1,6 +1,8 @@
 \newif\ifprp             \DeclareOption{prp}     {\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue                  \@bartrue \prptrue}
 \newif\ifgtes            \DeclareOption{gtes}    {\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue                  \@bartrue \gtestrue}
 \newif\ifcopyediting     \DeclareOption{copyediting}{\copyeditingtrue\@noreftrue}
+\newif\ifsmsps           \DeclareOption{smsps}   {                  \smspstrue}
+\newif\ifsand  \DeclareOption{sand}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\sandtrue}
 \newif\ifpolf  \DeclareOption{polf}{\@sansseriffacetrue\@sansserifheadertrue\@bartrue\polftrue}
 \newif\ifjbji  \DeclareOption{jbji}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\jbjitrue}
 \newif\ifmr  \DeclareOption{mr}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@twostagejnltrue\mrtrue}
@@ -21,7 +23,6 @@
 \newif\ifpiahs  \DeclareOption{piahs}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\piahstrue}
 \newif\ifascmo  \DeclareOption{ascmo}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@corrigendumtrue\@editorialnotetwoctrue\ascmotrue}
 \newif\ifpb  \DeclareOption{pb}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\pbtrue}
-\newif\ifap  \DeclareOption{ap}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\aptrue}
 \newif\ifsoil  \DeclareOption{soil}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@twostagejnltrue\soiltrue}
             \DeclareOption{soild}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@stage@finalfalse\soiltrue}
 \newif\ifangeocom  \DeclareOption{angeocom}{\@bartrue\@twostagejnltrue\angeocomtrue}
@@ -46,7 +47,6 @@
             \DeclareOption{dwesd}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@stage@finalfalse\dwestrue}
 \newif\iftc  \DeclareOption{tc}{\@twostagejnltrue\tctrue}
             \DeclareOption{tcd}{\@stage@finalfalse\tctrue}
-\newif\ifsmsps  \DeclareOption{smsps}{\smspstrue}
 \newif\ifse  \DeclareOption{se}{\@bartrue\@twostagejnltrue\setrue}
             \DeclareOption{sed}{\@bartrue\@stage@finalfalse\setrue}
 \newif\ifos  \DeclareOption{os}{\@twostagejnltrue\ostrue}
@@ -459,18 +459,6 @@
     \fi
   \fi
 \fi
-\ifsmsps%classical
-  \def\@journalname{Stephan Mueller Special Publication Series}
-  \def\@journalnameabbreviation{Stephan Mueller Spec. Publ. Ser.}
-  \def\@journalnameshort{SMSPS}
-  \def\@journalnameshortlower{smsps}
-  \def\@journalstartyear{2002}
-  \def\@sentence{Published by Copernicus Publications on behalf of the European Geosciences Union.}
-  \def\@journalurl{www.stephan-mueller-spec-publ-ser.net}
-  \def\@journallogo{\includegraphics{SMSPS_Logo.pdf}}
-  \definecolor{bgcol}{rgb}{1,1,1}
-  \definecolor{rulecol}{rgb}{1.0,1.0,1.0}
-\fi
 \iftc%classical
   \def\@journalname{The Cryosphere}
   \def\@journalnameabbreviation{The Cryosphere}
@@ -789,20 +777,6 @@
     \fi
   \fi
 \fi
-\ifap%classical
-  \def\@journalname{ASTRA Proceedings}
-  \def\@journalnameabbreviation{ASTRA Proc.}
-  \def\@journalnameshort{AP}
-  \def\@journalnameshortlower{ap}
-  \def\@journalstartyear{2014}
-  \def\@sentence{Published by Copernicus Publications.}
-  \def\@journalurl{www.astra-proceedings.net}
-  \def\@journallogo{\includegraphics{AP_Logo.pdf}}
-  \definecolor{textcol}{rgb}{0.094,0.259,0.647}
-  \definecolor{bgcol}{rgb}{1,1,1}
-  \definecolor{barcol}{rgb}{1.0,1.0,1.0}
-  \definecolor{rulecol}{rgb}{0.094,0.259,0.647}
-\fi
 \ifpb%classical
   \def\@journalname{Primate Biology}
   \def\@journalnameabbreviation{Primate Biol.}
@@ -850,7 +824,7 @@
   \def\@journalnameshort{AAB}
   \def\@journalnameshortlower{aab}
   \def\@journalstartyear{2015}
-  \def\@sentence{Published by Copernicus Publications on behalf of the Leibniz Institute for Farm Animal Biology (FBN).}
+  \def\@sentence{Published by Copernicus Publications on behalf of the Research Institute for Farm Animal Biology (FBN).}
   \def\@journalurl{www.arch-anim-breed.net}
   \def\@journallogo{\includegraphics{AAB_Logo.pdf}}
   \definecolor{textcol}{rgb}{0.6,0.0,0.0}
@@ -1060,6 +1034,20 @@
   \definecolor{textcol}{rgb}{0.306,0.525,0.682}
   \definecolor{bgcol}{rgb}{1,1,1}
   \definecolor{rulecol}{rgb}{1.0,1.0,1.0}
+\fi
+\ifsand%classical
+  \def\@journalname{Safety of Nuclear Waste Disposal}
+  \def\@journalnameabbreviation{Saf. Nucl. Waste Disposal}
+  \def\@journalnameshort{SAND}
+  \def\@journalnameshortlower{sand}
+  \def\@journalstartyear{2021}
+  \def\@sentence{Published by Copernicus Publications on behalf of the Bundesamt für die Sicherheit der nuklearen Entsorgung.}
+  \def\@journalurl{www.sand.copernicus.org}
+  \def\@journallogo{\includegraphics{SAND_Logo.pdf}}
+  \definecolor{textcol}{rgb}{0.0,0.0,0.0}
+  \definecolor{bgcol}{rgb}{1,1,1}
+  \definecolor{barcol}{rgb}{1.0,1.0,1.0}
+  \definecolor{rulecol}{rgb}{0.0,0.0,0.0}
 \fi
 
 }

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -48,7 +48,7 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.3, 8 July 2021, using \code{copernicus.cls} in version 9.32, 7 July 2021.
+\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.4, 8th August 2021, using \code{copernicus.cls} in version 9.32, 7 July 2021.
 
 \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 


### PR DESCRIPTION
Another update of the Copernicus template (now version 6.4) and I've added a so far missing journal ("Web Ecology") to `copernicus_article()`

- [x] Update NEWS.

