### PR TITLE
Copernicus template update to 6.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## NEW FEATURES
 
 - New `informs_article()` template for submissions to INFORMS journals (thanks, @robjhyndman, #460).
-- Update Copernicus Publications template to version 6.5 from 2021-12-15 (@RLumSK, #463)
+- Update Copernicus Publications template to version 6.6 from 2022-01-18 (@RLumSK, #463)
 
 # rticles 0.22
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## NEW FEATURES
 
 - New `informs_article()` template for submissions to INFORMS journals (thanks, @robjhyndman, #460).
-- Update Copernicus Publications template to version 6.6 from 2022-01-18 (@RLumSK, #463)
+- Update Copernicus Publications template to version 6.6 from 2022-01-18 (@RLumSK, #463, #464)
 
 # rticles 0.22
 

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -13,7 +13,7 @@
 #'
 #' An number of required and optional manuscript sections, e.g. `acknowledgements`, `competinginterests`, or `authorcontribution`, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' **Version:** Based on `copernicus_package.zip` in the version 6.5, 15 December 2021, using `copernicus.cls` in version 9.39, 9 December 2021.
+#' **Version:** Based on `copernicus_package.zip` in the version 6.6, 18 January 2022, using `copernicus.cls` in version 9.39, 9 December 2021.
 #'
 #' **Copernicus journal abbreviations:** You can use the function `copernicus_journal_abbreviations()` to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'
@@ -87,6 +87,7 @@ copernicus_journals <- list(
   "Earth System Dynamics" = "esd",
   "Earth System Science Data" = "essd",
   "E&G Quaternary Science Journal" = "egqsj",
+  "EGUsphere" = "egusphere",
   "European Journal of Mineralogy" = "ejm",
   "Fossil Record" = "fr",
   "Geochronology" = "gchron",

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_6.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_6.txt
@@ -1,7 +1,7 @@
 File: README_copernicus_package_6_5.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 6.5, 15 December 2021
+copernicus_package.zip in the version 6.6, 18 January 2022
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -16,7 +16,7 @@ URL:   	https://publications.copernicus.org
 
 Content:
 - copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.39, 8 December 2021
-- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 9 December 2021
+- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 18 January 2022
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.3, January 2021 
 - pdfscreencop.sty / pdfscreen.sty
 - template.tex: A LaTeX template in journal style.

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -32,6 +32,7 @@
 % Earth System Dynamics (esd)
 % Earth System Science Data (essd)
 % E&G Quaternary Science Journal (egqsj)
+% EGUsphere (egusphere) | This is only for EGUsphere preprints submitted without relation to an EGU journal.
 % European Journal of Mineralogy (ejm)
 % Fossil Record (fr)
 % Geochronology (gchron)
@@ -60,21 +61,6 @@
 % Weather and Climate Dynamics (wcd)
 % Web Ecology (we)
 % Wind Energy Science (wes)
-
-%% Please DO NOT add additional packages or LaTeX commands to the template. They
-%% are not supported by Coperncius. LaTeX packages already
-%% included in the copernicus.cls are:
-%\usepackage[german, english]{babel}
-%\usepackage{tabularx}
-%\usepackage{cancel}
-%\usepackage{multirow}
-%\usepackage{supertabular}
-%\usepackage{algorithmic}
-%\usepackage{algorithm}
-%\usepackage{amsthm}
-%\usepackage{float}
-%\usepackage{subfig}
-%\usepackage{rotating}
 
 % Pandoc citation processing
 $if(csl-refs)$

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
@@ -2,6 +2,8 @@
 \newif\ifgtes            \DeclareOption{gtes}    {\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue                  \@bartrue \gtestrue}
 \newif\ifcopyediting     \DeclareOption{copyediting}{\copyeditingtrue\@noreftrue}
 \newif\ifsmsps           \DeclareOption{smsps}   {                  \smspstrue}
+\newif\ifegusphere  \DeclareOption{egusphere}{\@twostagejnltrue\eguspheretrue}
+            \DeclareOption{egusphered}{\@stage@finalfalse\eguspheretrue}
 \newif\ifsand  \DeclareOption{sand}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\sandtrue}
 \newif\ifpolf  \DeclareOption{polf}{\@sansseriffacetrue\@sansserifheadertrue\@bartrue\polftrue}
 \newif\ifjbji  \DeclareOption{jbji}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\jbjitrue}
@@ -1052,6 +1054,30 @@
   \definecolor{bgcol}{rgb}{1,1,1}
   \definecolor{barcol}{rgb}{1.0,1.0,1.0}
   \definecolor{rulecol}{rgb}{0.0,0.0,0.0}
+\fi
+\ifegusphere%classical
+  \def\@journalname{EGUsphere}
+  \def\@journalnameabbreviation{EGUsphere}
+  \def\@journalnameshort{EGUSPHERE}
+  \def\@journalnameshortlower{egusphere}
+  \def\@journalstartyear{2022}
+  \def\@sentence{Published by Copernicus Publications on behalf of the European Geosciences Union.}
+  \if@stage@final
+    \def\@journalurl{https://egusphere.copernicus.org}
+    \def\@journallogo{\includegraphics{EGUSPHERE_Logo.pdf}}
+    \definecolor{bgcol}{rgb}{1,1,1}
+    \definecolor{rulecol}{rgb}{1.0,1.0,1.0}
+  \else
+    \def\@journalurl{https://egusphere.copernicus.org}
+    \def\@journallogo{\includegraphics{EGUSPHERE_Logo.pdf}}
+    \def\@sentenceDiscussion{}
+    \if@cop@home
+      \definecolor{journalname}{rgb}{0.0,0.0,0.0}
+      \definecolor{buttonbackground}{rgb}{0.0,0.0,0.0}
+      \definecolor{paneltext}{rgb}{0.0,0.0,0.0}
+      \definecolor{buttontext}{rgb}{0.0,0.0,0.0}
+    \fi
+  \fi
 \fi
 
 }

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -48,7 +48,7 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.5, 15 December 2021, using \code{copernicus.cls} in version 9.39, 9 December 2021.
+\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.6, 18 January 2022, using \code{copernicus.cls} in version 9.39, 9 December 2021.
 
 \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 


### PR DESCRIPTION
And yet another template updated based on the template released 18th January 2022. @nuest 

- [x] Update Rd and namespace (could be done by `devtools::document()`).

- [x] Update NEWS.

