### PR TITLE
Update Journal of Statistical Software template and class file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Authors@R: c(
   person("JooYoung", "Seo", role=c("ctb"), email="jseo1005@illinois.edu", comment = c(ORCID = "0000-0002-4064-6012")),
   person("Callum", "Arnold", role = c("ctb"), email = "cal.rk.arnold@gmail.com", comment = c(github = "arnold-c")),
   person("Rob", "Hyndman", role = c("aut"), email = "Rob.Hyndman@monash.edu", comment = c(ORCID = "0000-0002-2140-5352")),
-  person("Dmytro", "Perepolkin", role = c("ctb"), email = "dperepolkin@gmail.com", comment = c(ORCID = "0000-0001-8558-6183", github = "dmi3kno"))
+  person("Dmytro", "Perepolkin", role = c("ctb"), email = "dperepolkin@gmail.com", comment = c(ORCID = "0000-0001-8558-6183", github = "dmi3kno")),
+  person("Tom", "Palmer", role = c("ctb"), email = "remlapmot@hotmail.com", comment = c(ORCID = "0000-0003-4655-4511", github = "remlapmot"))
   )
 Description: A suite of custom R Markdown formats and templates for
   authoring journal articles and conference submissions.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rticles
 Type: Package
 Title: Article Formats for R Markdown
-Version: 0.22.2
+Version: 0.22.3
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## NEW FEATURES
 
+- Update Journal of Statistical Software template to use its updated class file and if specified in the YAML header of the Rmd file add ORCID links for each author (thanks, @remlapmot, #465).
+
 - New `informs_article()` template for submissions to INFORMS journals (thanks, @robjhyndman, #460).
 
 - New `isba_article()` template for submissions to Bayesian Analysis journal (thanks, @dmi3kno, #461).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- Update Journal of Statistical Software template to use its updated class file and if specified in the YAML header of the Rmd file add ORCID links for each author (thanks, @remlapmot, #465).
+- Update `jss_article()` template to handle ORCID links for each author from  a new YAML field, and to use updated `jss.cls` class file (thanks, @remlapmot, #465).
 
 - New `informs_article()` template for submissions to INFORMS journals (thanks, @robjhyndman, #460).
 

--- a/inst/rmarkdown/templates/jss/resources/template.tex
+++ b/inst/rmarkdown/templates/jss/resources/template.tex
@@ -7,7 +7,7 @@ $endfor$
 \usepackage[utf8]{inputenc}
 
 \author{
-$for(author)$$author.name$\\$author.affiliation$$sep$ \And $endfor$
+$for(author)$$author.name$$if(author.orcid)$~\orcidlink{$author.orcid$}$endif$\\$author.affiliation$$sep$ \And $endfor$
 }
 \title{$title.formatted$}
 

--- a/inst/rmarkdown/templates/jss/resources/template.tex
+++ b/inst/rmarkdown/templates/jss/resources/template.tex
@@ -4,6 +4,9 @@ $for(classoption)$
 $endfor$
 ]{$documentclass$}
 
+%% recommended packages
+\usepackage{orcidlink,thumbpdf,lmodern}
+
 \usepackage[utf8]{inputenc}
 
 \author{

--- a/inst/rmarkdown/templates/jss/skeleton/jss.cls
+++ b/inst/rmarkdown/templates/jss/skeleton/jss.cls
@@ -1,8 +1,8 @@
 %%
-%% This is file `jss.cls'
-\def\fileversion{3.2}
+%% This is file `jss.cls',
+\def\fileversion{3.3}
 \def\filename{jss}
-\def\filedate{2020/12/09}
+\def\filedate{2021/05/23}
 %%
 %% Package `jss' to use with LaTeX2e for JSS publications (http://www.jstatsoft.org/)
 %% License: GPL-2 | GPL-3
@@ -51,7 +51,7 @@
 \ProcessOptions
 \LoadClass[11pt,a4paper,twoside]{article}
 %% required packages
-\RequirePackage{graphicx,color,ae,fancyvrb}
+\RequirePackage{graphicx,xcolor,ae,fancyvrb}
 \RequirePackage[T1]{fontenc}
 \IfFileExists{upquote.sty}{\RequirePackage{upquote}}{}
 \IfFileExists{lmodern.sty}{\RequirePackage{lmodern}}{}

--- a/inst/rmarkdown/templates/jss/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/jss/skeleton/skeleton.Rmd
@@ -2,6 +2,7 @@
 documentclass: jss
 author:
   - name: FirstName LastName
+    orcid: 0000-0000-0000-0000
     affiliation: University/Company
     # use this syntax to add text on several lines
     address: |
@@ -10,9 +11,11 @@ author:
     email: \email{name@company.com}
     url: http://rstudio.com
   - name: Second Author
+    orcid: 0000-0000-0000-0000
     affiliation: 'Affiliation \AND'
     # To add another line, use \AND at the end of the previous one as above
   - name: Third Author
+    orcid: 0000-0000-0000-0000
     address: |
       | Department of Statistics and Mathematics,
       | Faculty of Biosciences,


### PR DESCRIPTION
I noticed that the JSS jss.cls file had been updated.

This PR

- updates jss.cls to use last year's updated version [here](https://www.jstatsoft.org/public/journals/1/jss-article-tex.zip)
- adds `\orcidlink{}` to each author if `orcid:` specified in the Rmd YAML header
- adds missing `\usepackage{}` line to template.tex from the JSS article.tex example file.

(Nb. I have no affiliation to the journal, I was just using the current **rticles** version and noticed that it was 1 version behind.)
