### PR TITLE
Copernicus Template Update 6.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## MINOR CHANGES
 
-- Update Copernicus Publications template to version 6.8 from 2022-03-28 (@RLumSK, #478).
+- Update Copernicus Publications template to version 6.8 from 2022-03-28 (@RLumSK, #478, #479).
 
 # rticles 0.23
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## MINOR CHANGES
 
-- Update Copernicus Publications template to version 6.7 from 2022-03-16 (@RLumSK, #478).
+- Update Copernicus Publications template to version 6.8 from 2022-03-28 (@RLumSK, #478).
 
 # rticles 0.23
 

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -13,7 +13,7 @@
 #'
 #' An number of required and optional manuscript sections, e.g. `acknowledgements`, `competinginterests`, or `authorcontribution`, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' **Version:** Based on `copernicus_package.zip` in the version 6.7, 16 March 2022, using `copernicus.cls` in version 9.44, 3 March  2022.
+#' **Version:** Based on `copernicus_package.zip` in the version 6.7, 16 March 2022, using `copernicus.cls` in version 9.46, 25 March  2022.
 #'
 #' **Copernicus journal abbreviations:** You can use the function `copernicus_journal_abbreviations()` to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_8.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_8.txt
@@ -1,7 +1,7 @@
-File: README_copernicus_package_6_7.txt
+File: README_copernicus_package_6_8.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 6.7, 16 March 2022
+copernicus_package.zip in the version 6.8, 28 March 2022
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -15,7 +15,7 @@ URL:   	https://publications.copernicus.org
 
 
 Content:
-- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.44, 3 March 2022
+- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.46, 25 March 2022
 - copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 18 January 2022
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.4, March 2022 
 - pdfscreencop.sty / pdfscreen.sty

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
@@ -16,7 +16,7 @@
 %% -----------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{copernicus}
-    [2022/03/03 9.44 Copernicus papers]
+    [2022/03/25 9.46 Copernicus papers]
 \frenchspacing
 \clubpenalty10000
 \widowpenalty10000
@@ -70,6 +70,7 @@
 \newif\if@noauthor       \DeclareOption{noauthor}{\@noauthortrue}
 \newif\if@nolastpage     \DeclareOption{nolastpage}{\@nolastpagetrue}
 \newif\if@noref          \DeclareOption{noref}{\@noreftrue}
+\newif\if@copDebug       \DeclareOption{debug}{\@copDebugtrue}
 \newif\if@nohyperref     \DeclareOption{nohyperref}{\@nohyperreftrue}
 \newif\if@cop@home       \IfFileExists{copernicuslogo.pdf}{\@cop@hometrue}{\@cop@homefalse}
 \newif\ifonline          \DeclareOption{online}{\onlinetrue}
@@ -1822,6 +1823,27 @@
     {\CopernicusWarningNoLine{Cannot find subfig.sty; proceeding without it}}
 \fi
 \let\@makecaption\cop@makecaption
+\RequirePackage{listings}
+\newdimen\listingnumwidth \listingnumwidth=1.25em\relax
+\renewcommand*\thelstnumber{\hb@xt@\listingnumwidth{\hss\the\c@lstnumber:}}
+\lstset{%
+  basicstyle=\small,%
+  numbers=left,%
+  numbersep=0.5em,%
+  numberstyle=\footnotesize,%
+  frame=lines,%
+  xleftmargin=\dimexpr\listingnumwidth+0.5em\relax,%
+  framexleftmargin=\dimexpr\listingnumwidth+0.5em\relax,
+}
+\newenvironment{listing}[1][]
+ {\edef\@argi{#1}%
+  \ifx\@argi\@empty\def\@argi{htbp}\fi
+  \setlistings
+  \lstset{aboveskip=0pt,belowskip=0pt}%
+  \def\@tempa{\begin{figure}}%
+    \expandafter\@tempa\expandafter[\@argi]}
+ {\end{figure}%
+  \setfigures}
 \IfFileExists{subfloat.sty}
   {\RequirePackage{subfloat}%
    \protected@xdef\themainfigure{\thefigure}%
@@ -2816,8 +2838,10 @@
 }
 {\endlist}
 
-\ifx\xmltexversion\@undefined
-\DeclareUnicodeCharacter{200B}{{\unskip\;\color{red}\vrule \@width1ex \@height1ex}}
+\if@copDebug
+  \ifx\xmltexversion\@undefined
+    \DeclareUnicodeCharacter{200B}{{\unskip\;\color{red}\vrule \@width1ex \@height1ex}}
+  \fi
 \fi
 \endinput
 %%

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -57,7 +57,7 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.7, 16 March 2022, using \code{copernicus.cls} in version 9.44, 3 March  2022.
+\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.7, 16 March 2022, using \code{copernicus.cls} in version 9.46, 25 March  2022.
 
 \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 


### PR DESCRIPTION
Sorry, and yet another update of the Copernicus template (@nuest). Yesterday, I must have just downloaded the latest version while an even newer version came probably online just minutes or hours later. 

Interesting: Now they finally support the LaTeX `listings` package, but adding "--listings" as an additional pandoc argument does not seem to work. Moreover, it is part of the *.cls file but not (yet) mentioned in their template file. We should watch it and add this with another update once also the LaTeX template mentions this option. 

- [X] Update Rd and namespace (could be done by `devtools::document()`).

- [X] Update NEWS.
