### PR TITLE
Fix nested code chunk in markdown list for `jss_article()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rticles (development version)
 
+## BUG FIXES
+
+- Nested code chunk in list are now correctly rendered in `jss_article()` (thanks, @nbenn, #476).
+
 ## MINOR CHANGES
 
 - Update Copernicus Publications template to version 6.7 from 2022-03-16 (@RLumSK, #478).

--- a/R/jss_article.R
+++ b/R/jss_article.R
@@ -77,7 +77,10 @@ latex_block <- function(hook) {
   force(hook)
   function(x, options) {
     x2 <- hook(x, options)
-    if (identical(x, x2)) x else paste0("```{=latex}\n", x2, "\n```")
+    x3 <- if (identical(x, x2)) x else paste0("```{=latex}\n", x2, "\n```")
+    if (is.null(s <- options$indent)) return(x3)
+    # knitr:::line_prompt equivalent
+    paste0(s, gsub('(?<=\n)(?=.|\n)', s, x3, perl = TRUE))
   }
 }
 


### PR DESCRIPTION
Fix #476 by taking into account options$indent in JSS article special hooks