### PR TITLE
Update Glossa article

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rticles
 Title: Article Formats for R Markdown
-Version: 0.23.5
+Version: 0.23.6
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## BUG FIXES
 
+- Update `glossa_article()` and path template to opt-out using `microtype` to prevent issues. Add it back using `extra_dependencies` in YAML with adding a preamble if needed (thanks, @stefanocoretta, #487).
+
 - In `elsevier_article()`, corresponding author is correctly marked with a `*` even if no other footnote are set on the author.
 
 - `ams_article()` bundles `ametsoc.cls` now as **ametsoc** package is not more available on CTAN.

--- a/inst/rmarkdown/templates/glossa/skeleton/glossa.bst
+++ b/inst/rmarkdown/templates/glossa/skeleton/glossa.bst
@@ -5,6 +5,7 @@
 %%% created by Patrick W Daly. There have been some hand-coded adjustments to that
 %%% style to get the style closer to the Unified Style Sheet for Linguistics Journals.
 %%%
+%%% Version 1.3 [2021/7/1] changed the internal order of names to last-first throughout, and & between all names in name lists, in accordance with Haspelmath's `The Generic Style Rules for Linguistics'.
 %%% Version 1.2 [2017/2/16] corrected minor mistake (to get a comma preceding page numbers of articles in edited volumes)
 %%% Version 1.1 [2016/12/24] rewrote the function format.number.series to improve the treatment of book series (series title in to appear in roman font between brackets followed by optional number field)
 %%% Version 1.0 [2016/04/21] last names with a prefix have the prefix first and are alphabetized accordingly
@@ -101,7 +102,10 @@ FUNCTION {output.check}
   if$
 }
 FUNCTION {fin.entry}
-{ add.period$
+{ doi empty$
+    { add.period$ }
+    { }
+  if$
   write$
   newline$
 }
@@ -426,7 +430,9 @@ FUNCTION {format.names.ed}
       nameptr #1 >
         {
           namesleft #1 >
-            { ", " * t * }
+            { 
+            	bbl.and
+				space.word * t * }
             {
               s nameptr "{ll}" format.name$ duplicate$ "others" =
                 { 't := }

--- a/inst/rmarkdown/templates/glossa/skeleton/glossa.cls
+++ b/inst/rmarkdown/templates/glossa/skeleton/glossa.cls
@@ -122,7 +122,7 @@
   \RequirePackage[bitstream-charter]{mathdesign} %math font close to Charis SIL
   \RequirePackage[no-math]{fontspec}
   \setmainfont{CharisSIL}
-  \RequirePackage{FiraSans} %sf font
+  \RequirePackage{FiraSans} %sf font; download from https://www.fontsquirrel.com/fonts/fira-sans
   \RequirePackage{amssymb}
   \RequirePackage{textcomp}
   \else\relax

--- a/inst/rmarkdown/templates/glossa/skeleton/glossa.cls
+++ b/inst/rmarkdown/templates/glossa/skeleton/glossa.cls
@@ -1,4 +1,4 @@
-% Glossa stylefile, modified from the 
+% Glossa stylefile, modified from the
 % Semantics & Pragmatics style file.
 % Kai von Fintel, Christopher Potts, and Chung-chieh Shan
 % modifications for Glossa by Guido Vanden Wyngaerd
@@ -17,17 +17,17 @@
 \ProvidesClass{glossa}[2018/01/27 v.2.3 Class for Glossa]
 
 % OUTLINE OF THIS CLASS FILE
-%   option declarations 
-%   required packages 
-%   metadata 
-%   page dimensions 
-%   title 
-%   running headers 
-%   frontmatter 
-%   sectioning 
-%   footnotes 
-%   backmatter 
-%   other environments 
+%   option declarations
+%   required packages
+%   metadata
+%   page dimensions
+%   title
+%   running headers
+%   frontmatter
+%   sectioning
+%   footnotes
+%   backmatter
+%   other environments
 %   useful macros
 
 %=====================================================================
@@ -45,7 +45,7 @@
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 
 \newcommand{\@sizeoption@err}{\ClassError{sp}
-  {Cannot use size option \CurrentOption} 
+  {Cannot use size option \CurrentOption}
   {Glossa style requires (and automatically loads) 11pt text}}
 
 \DeclareOption{10pt}{\@sizeoption@err}
@@ -68,16 +68,16 @@
  \IfFileExists{lucimatx.sty}{%
     \RequirePackage[romanfamily=bright-osf, scale=0.9, stdmathdigits=true]{lucimatx}%
     \linespread{1.05}%
-    \DeclareMathDelimiter{\llbracket} 
-      {\mathopen}{letters}{130}{largesymbols}{130} 
-    \DeclareMathDelimiter{\rrbracket} 
+    \DeclareMathDelimiter{\llbracket}
+      {\mathopen}{letters}{130}{largesymbols}{130}
+    \DeclareMathDelimiter{\rrbracket}
       {\mathclose}{letters}{131}{largesymbols}{131}
     \normalfont\DeclareTextCommand
       \textbullet\encodingdefault{\UseTextSymbol{OMS}\textbullet}
     \let\nLeftrightarrow\undefined
     \DeclareMathSymbol{\nLeftrightarrow}{\mathrel}{arrows}{105}
-}{\ClassWarning{glossa.cls}{Requested fonts not present}}% 
-\else\relax 
+}{\ClassWarning{glossa.cls}{Requested fonts not present}}%
+\else\relax
 \fi
 %
 \if@times
@@ -87,7 +87,7 @@
     {\RequirePackage{stmaryrd}}%
     {\newcommand{\llbracket}{\ensuremath{\left [\!\left [}}%
      \newcommand{\rrbracket}{\ensuremath{\right ]\!\right ]}}}
-  \RequirePackage{textcomp}   
+  \RequirePackage{textcomp}
   \RequirePackage{amssymb}
   \else\relax
 \fi
@@ -152,10 +152,10 @@
 %%% End modification
 
 \RequirePackage{xspace}
-% microtype handles punctuation at the right margin. We want it for the final product, but it's okay if authors lack it.
-\IfFileExists{microtype.sty}{%
-  \RequirePackage[final,protrusion={true,compatibility}]{microtype}
-}{}
+% microtype handles punctuation at the right margin. We want it for the final product, but it's okay if authors lack it. MODIFIED by Coretta 2022-05-23 comment out microtype to circumvent error during compilation
+% \IfFileExists{microtype.sty}{%
+%   \RequirePackage[final,protrusion={true,compatibility}]{microtype}
+% }{}
 \RequirePackage{ifthen}
 \RequirePackage[hyphens]{url}
 
@@ -183,13 +183,13 @@
     \newcommand{\seccitep}[2]{(\citealt{#1}:~$\S$#2)}
     \newcommand{\pgcitet}[2]{\citeauthor{#1} (\citeyear{#1}:~#2)}
     \newcommand{\seccitet}[2]{\citeauthor{#1} (\citeyear{#1}:~$\S$#2)}
-\fi	
+\fi
 
 \RequirePackage[usenames,dvipsnames]{xcolor}
 \definecolor{splinkcolor}{rgb}{.0,.2,.4}
 \RequirePackage[colorlinks,breaklinks,
-                linkcolor=splinkcolor, 
-                urlcolor=splinkcolor, 
+                linkcolor=splinkcolor,
+                urlcolor=splinkcolor,
                 citecolor=splinkcolor,
                 filecolor=splinkcolor,
                 plainpages=false,
@@ -228,7 +228,7 @@
 \def\@pdfkeywords{\relax}
 \newcommand{\pdfkeywords}[1]{\gdef\@pdfkeywords{#1}}
 
-\hypersetup{pdfauthor=\@pdfauthor, 
+\hypersetup{pdfauthor=\@pdfauthor,
             pdftitle=\@pdftitle,
             pdfkeywords=\@pdfkeywords}
 
@@ -244,7 +244,7 @@
 \def\@spdoi{10.5334/.\@spvolume.\@sparticle}
 \def\@splastpage{\relax}
 \newcommand{\splastpage}[1]{\gdef\@splastpage{#1}}
-            
+
 %=====================================================================
 %========================== page dimensions ==========================
 
@@ -299,8 +299,8 @@
 }
 
 % From salt.cls.
-\newskip\onelineskip 
-\onelineskip=\baselineskip 
+\newskip\onelineskip
+\onelineskip=\baselineskip
 \advance\onelineskip by0pt plus 4pt minus 2pt
 
 \def\@maketitle{%
@@ -363,7 +363,7 @@
         }{}% else nothing; closes \IfFileExists
         \else
         % If the ps logo is present,
-        \IfFileExists{sp-logo.ps}{%   
+        \IfFileExists{sp-logo.ps}{%
           % then insert the postscript version,
           \begin{minipage}[c]{.25in}
             \includegraphics[width=.25in]{sp-logo.ps}
@@ -406,7 +406,7 @@
         }{}% else nothing; closes \IfFileExists
         \else
         % If the ps logo is present,
-        \IfFileExists{sp-logo.ps}{%   
+        \IfFileExists{sp-logo.ps}{%
           % then insert the postscript version,
           \begin{minipage}[c]{.25in}
             \includegraphics[width=.25in]{sp-logo}
@@ -443,7 +443,7 @@
   \def\@evenfoot{%\hfill{\headerfontsize\ifx\@empty\@articlenumber\else\@articlenumber:\fi\thepage}\hfill
   }% centered pg no
 }
-\pagestyle{spheadings}         
+\pagestyle{spheadings}
 
 %=====================================================================
 %=========================== final typeset ===========================
@@ -453,9 +453,9 @@
 \RequirePackage{sp-hyperxmp}
 \splogo
 \AtBeginDocument{\firstpagefinalheadings}
-\else            
+\else
 \nosplogo
-\AtBeginDocument{\thispagestyle{plain}} 
+\AtBeginDocument{\thispagestyle{plain}}
 \fi
 
 


### PR DESCRIPTION
Fixing error in glossa article when rendering, caused by microtype.

The authors of the `glossa.cls` say in the comments that the microtype LaTeX package is used in production but it's fine if the authors don't have it. So the code loading microtype is now commented out. This solution is a workaround but works both for those using TinyTex and a non-TinyTex installation.
