### PR TITLE
Enable natbib option for `asa_article()`

### DIFF
--- a/inst/rmarkdown/templates/asa/resources/template.tex
+++ b/inst/rmarkdown/templates/asa/resources/template.tex
@@ -3,7 +3,11 @@
 \usepackage{amsmath}
 \usepackage{graphicx,psfrag,epsf}
 \usepackage{enumerate}
+
+$if(natbib)$
 \usepackage{natbib}
+$endif$
+
 \usepackage{textcomp}
 \usepackage[hyphens]{url} % not crucial - just used below for the URL
 \usepackage{hyperref}


### PR DESCRIPTION
The documentation for `asa_article` indicates that it takes the `citation_package` option. However, the template did not provide any option to omit the natbib package.  This PR allows the natbib package to be included or omitted from the asa template, following the same format as the [`jasa_article` template](https://github.com/rstudio/rticles/blob/main/inst/rmarkdown/templates/jasa/resources/template.tex).