### PR TITLE
Copernicus template update to v7.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rticles
 Title: Article Formats for R Markdown
-Version: 0.24.3
+Version: 0.24.4
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
     - Update to template following the guidelines
     - Better support for links in template to be closer to guidelines
 
-- Update Copernicus Publications template to version 6.9 from 2022-09-26 (@RLumSK, #508)
+- Update Copernicus Publications template to version 7.1 from 2022-12-06 (@RLumSK, #508)
 
 # rticles 0.24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
     - Update to template following the guidelines
     - Better support for links in template to be closer to guidelines
 
-- Update Copernicus Publications template to version 6.9 from 2022-09-26 (@RLumSK)
+- Update Copernicus Publications template to version 6.9 from 2022-09-26 (@RLumSK, #508)
 
 # rticles 0.24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
     - Update to template following the guidelines
     - Better support for links in template to be closer to guidelines
 
+- Update Copernicus Publications template to version 6.9 from 2022-09-26 (@RLumSK)
+
 # rticles 0.24
 
 ## NEW FEATURES

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -13,7 +13,7 @@
 #'
 #' An number of required and optional manuscript sections, e.g. `acknowledgements`, `competinginterests`, or `authorcontribution`, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' **Version:** Based on `copernicus_package.zip` in the version 6.7, 16 March 2022, using `copernicus.cls` in version 9.46, 25 March  2022.
+#' **Version:** Based on `copernicus_package.zip` in the version 6.9, 26 September 2022, using `copernicus.cls` in version 9.46, 25 March 2022.
 #'
 #' **Copernicus journal abbreviations:** You can use the function `copernicus_journal_abbreviations()` to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -13,7 +13,7 @@
 #'
 #' An number of required and optional manuscript sections, e.g. `acknowledgements`, `competinginterests`, or `authorcontribution`, must be declared using the respective properties of the R Markdown header - see skeleton file.
 #'
-#' **Version:** Based on `copernicus_package.zip` in the version 6.9, 26 September 2022, using `copernicus.cls` in version 9.46, 25 March 2022.
+#' **Version:** Based on `copernicus_package.zip` in the version 7.1, 06 December 2022, using `copernicus.cls` in version 10.1.4, 06 December 2022.
 #'
 #' **Copernicus journal abbreviations:** You can use the function `copernicus_journal_abbreviations()` to get the journal abbreviation for all journals supported by the Copernicus article template.
 #'

--- a/R/copernicus_article.R
+++ b/R/copernicus_article.R
@@ -113,6 +113,7 @@ copernicus_journals <- list(
   "Scientific Drilling" = "sd",
   "SOIL" = "soil",
   "Solid Earth" = "se",
+  "State of the Planet" = "sp",
   "The Cryosphere" = "tc",
   "Web Ecology" = "we",
   "Weather and Climate Dynamics" = "wcd",

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_9.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_6_9.txt
@@ -1,7 +1,7 @@
-File: README_copernicus_package_6_8.txt
+File: README_copernicus_package_6_9.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 6.8, 28 March 2022
+copernicus_package.zip in the version 6.9, 26 September 2022
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -16,7 +16,7 @@ URL:   	https://publications.copernicus.org
 
 Content:
 - copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.46, 25 March 2022
-- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 18 January 2022
+- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 26 September 2022
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.4, March 2022 
 - pdfscreencop.sty / pdfscreen.sty
 - template.tex: A LaTeX template in journal style.

--- a/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_7_1.txt
+++ b/inst/rmarkdown/templates/copernicus/resources/README_copernicus_package_7_1.txt
@@ -1,7 +1,7 @@
-File: README_copernicus_package_6_9.txt
+File: README_copernicus_package_7_1.txt
 -------------------------------------------------------------------------
 This is a README file for the Copernicus Publications LaTeX Macro Package 
-copernicus_package.zip in the version 6.9, 26 September 2022
+copernicus_package.zip in the version 7.1, 6 December 2022
 -------------------------------------------------------------------------
 It consists of several files, each with its separate copyright.
 This specific archive is collected for journals published by 
@@ -15,8 +15,8 @@ URL:   	https://publications.copernicus.org
 
 
 Content:
-- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 9.46, 25 March 2022
-- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 26 September 2022
+- copernicus.cls: The LaTeX2e class file designed for Copernicus Publications journals. Current Version 10.1.4, 5 December 2022
+- copernicus.cfg: The configuration file containing journal-specific information used by the class file. Last update 24 November 2022
 - copernicus.bst: The bibliographic style file for BibTeX. Current Version 1.4, March 2022 
 - pdfscreencop.sty / pdfscreen.sty
 - template.tex: A LaTeX template in journal style.

--- a/inst/rmarkdown/templates/copernicus/resources/template.tex
+++ b/inst/rmarkdown/templates/copernicus/resources/template.tex
@@ -57,6 +57,7 @@
 % Scientific Drilling (sd)
 % SOIL (soil)
 % Solid Earth (se)
+% State of the Planet (sp)
 % The Cryosphere (tc)
 % Weather and Climate Dynamics (wcd)
 % Web Ecology (we)

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
@@ -2,6 +2,8 @@
 \newif\ifgtes            \DeclareOption{gtes}    {\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue                  \@bartrue \gtestrue}
 \newif\ifcopyediting     \DeclareOption{copyediting}{\copyeditingtrue\@noreftrue}
 \newif\ifsmsps           \DeclareOption{smsps}   {                  \smspstrue}
+\newif\ifsp  \DeclareOption{sp}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@firstbartrue\@twostagejnltrue\sptrue}
+            \DeclareOption{spd}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@firstbartrue\@stage@finalfalse\sptrue}
 \newif\ifegusphere  \DeclareOption{egusphere}{\@twostagejnltrue\eguspheretrue}
             \DeclareOption{egusphered}{\@stage@finalfalse\eguspheretrue}
 \newif\ifsand  \DeclareOption{sand}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\sandtrue}
@@ -59,8 +61,8 @@
             \DeclareOption{nhessd}{\@stage@finalfalse\nhesstrue}
 \newif\ifhess  \DeclareOption{hess}{\@twostagejnltrue\hesstrue}
             \DeclareOption{hessd}{\@stage@finalfalse\hesstrue}
-\newif\ifgmd  \DeclareOption{gmd}{\@twostagejnltrue\gmdtrue}
-            \DeclareOption{gmdd}{\@stage@finalfalse\gmdtrue}
+\newif\ifgmd  \DeclareOption{gmd}{\@firstbartrue\@twostagejnltrue\gmdtrue}
+            \DeclareOption{gmdd}{\@firstbartrue\@stage@finalfalse\gmdtrue}
 \newif\ifgi  \DeclareOption{gi}{\@corrigendumtrue\@editorialnotetwoctrue\@editorialnotedtrue\@twostagejnltrue\gitrue}
             \DeclareOption{gid}{\@stage@finalfalse\gitrue}
 \newif\ifesd  \DeclareOption{esd}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@bartrue\@twostagejnltrue\esdtrue}
@@ -331,8 +333,10 @@
   \if@stage@final
     \def\@journalurl{www.geosci-model-dev.net}
     \def\@journallogo{\includegraphics{GMD_Logo.pdf}}
+    \definecolor{textcol}{rgb}{0.0,0.0,0.0}
     \definecolor{bgcol}{rgb}{1,1,1}
-    \definecolor{rulecol}{rgb}{1.0,1.0,1.0}
+    \definecolor{barcol}{rgb}{1.0,1.0,1.0}
+    \definecolor{rulecol}{rgb}{0.973,0.584,0.055}
   \else
     \def\@journalurl{www.geosci-model-dev-discuss.net}
     \def\@journallogo{\includegraphics{GMDD_Logo.pdf}}
@@ -1076,6 +1080,32 @@
       \definecolor{buttonbackground}{rgb}{0.0,0.0,0.0}
       \definecolor{paneltext}{rgb}{0.0,0.0,0.0}
       \definecolor{buttontext}{rgb}{0.0,0.0,0.0}
+    \fi
+  \fi
+\fi
+\ifsp%classical
+  \def\@journalname{State of the Planet}
+  \def\@journalnameabbreviation{State Planet}
+  \def\@journalnameshort{SP}
+  \def\@journalnameshortlower{sp}
+  \def\@journalstartyear{2023}
+  \def\@sentence{Published by Copernicus Publications.}
+  \if@stage@final
+    \def\@journalurl{https://sp.copernicus.org/}
+    \def\@journallogo{\includegraphics{SP_Logo.pdf}}
+    \definecolor{textcol}{rgb}{0.008,0.239,0.365}
+    \definecolor{bgcol}{rgb}{1,1,1}
+    \definecolor{barcol}{rgb}{1.0,1.0,1.0}
+    \definecolor{rulecol}{rgb}{0.008,0.239,0.365}
+  \else
+    \def\@journalurl{}
+    \def\@journallogo{\includegraphics{SPD_Logo.pdf}}
+    \def\@sentenceDiscussion{}
+    \if@cop@home
+      \definecolor{journalname}{rgb}{1.0,1.0,1.0}
+      \definecolor{buttonbackground}{rgb}{1.0,1.0,1.0}
+      \definecolor{paneltext}{rgb}{1.0,1.0,1.0}
+      \definecolor{buttontext}{rgb}{1.0,1.0,1.0}
     \fi
   \fi
 \fi

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cfg
@@ -55,8 +55,8 @@
             \DeclareOption{sed}{\@bartrue\@stage@finalfalse\setrue}
 \newif\ifos  \DeclareOption{os}{\@twostagejnltrue\ostrue}
             \DeclareOption{osd}{\@stage@finalfalse\ostrue}
-\newif\ifnpg  \DeclareOption{npg}{\@editorialnotedtrue\@twostagejnltrue\npgtrue}
-            \DeclareOption{npgd}{\@stage@finalfalse\npgtrue}
+\newif\ifnpg  \DeclareOption{npg}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@firstbartrue\@editorialnotedtrue\@twostagejnltrue\npgtrue}
+            \DeclareOption{npgd}{\@sansseriffacetrue\@sansserifheadertrue\@abstractcenteredtrue\@firstbartrue\@stage@finalfalse\npgtrue}
 \newif\ifnhess  \DeclareOption{nhess}{\@editorialnotedtrue\@twostagejnltrue\nhesstrue}
             \DeclareOption{nhessd}{\@stage@finalfalse\nhesstrue}
 \newif\ifhess  \DeclareOption{hess}{\@twostagejnltrue\hesstrue}
@@ -407,8 +407,10 @@
   \if@stage@final
     \def\@journalurl{www.nonlin-processes-geophys.net}
     \def\@journallogo{\includegraphics{NPG_Logo.pdf}}
+    \definecolor{textcol}{rgb}{0.102,0.278,0.6}
     \definecolor{bgcol}{rgb}{1,1,1}
-    \definecolor{rulecol}{rgb}{1.0,1.0,1.0}
+    \definecolor{barcol}{rgb}{1.0,1.0,1.0}
+    \definecolor{rulecol}{rgb}{0.102,0.278,0.6}
   \else
     \def\@journalurl{www.nonlin-processes-geophys-discuss.net}
     \def\@journallogo{\includegraphics{NPGD_Logo.pdf}}

--- a/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
+++ b/inst/rmarkdown/templates/copernicus/skeleton/copernicus.cls
@@ -16,10 +16,21 @@
 %% -----------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{copernicus}
-    [2022/03/25 9.46 Copernicus papers]
+    [2022/12/05 10.1.4 Copernicus papers]
 \frenchspacing
 \clubpenalty10000
 \widowpenalty10000
+\RequirePackage{iftex}
+%% protrudechars, \adjustspacing \hypenationmin,
+%% lccode, \hjcode ???, exhyphenchar,\automatichyphenmode, hyphenchar
+\newcommand*\@iflatexlater{\@ifl@t@r\fmtversion}
+\@iflatexlater{2020/10/01}{}{\RequirePackage{ifluatex}\RequirePackage{ifxetex}}
+\ifluatex
+  \let\pdfoutput\outputmode
+  \edef\pdfpageattr{\pdfvariable pageattr}
+  \RequirePackage{newunicodechar}
+\fi
+%% \RequirePackage{fixltx2e}[2006/03/24]
 \protected@edef\CopernicusInfo#1{\protect\ClassInfo{copernicus}{#1}}
 \protected@edef\CopernicusWarningNoLine#1{\protect\ClassWarningNoLine{copernicus}{#1}}
 \protected@edef\CopernicusError#1#2{\protect\ClassError{copernicus}{#1}{#2}}
@@ -30,7 +41,6 @@
  {\CopernicusWarningNoLine{No section #1; proceeding without it}}
 \newcommand\NoSectionError[2]
  {\CopernicusError{You forgot the section: #1}{Add #2 to your document!}}
-\RequirePackage{fixltx2e}[2006/03/24]
 \renewcommand*\and{\@centercr}
 \AtEndOfClass{%
   \DeclareRobustCommand*{\vec}[1]
@@ -39,6 +49,36 @@
                 {\mbox{\boldmath$\textstyle#1$}}
                 {\mbox{\boldmath$\scriptstyle#1$}}
                 {\mbox{\boldmath$\scriptscriptstyle#1$}}}}}
+
+\newcommand{\xmp@keywords}[1]{%
+  \begingroup
+    \let\hack\@gobble
+    \protected@xdef\@xmp@keywords{#1}%
+  \endgroup
+}
+\xmp@keywords{}%
+\newcommand{\xmp@title}[1]{%
+  \begingroup
+    \let\hack\@gobble
+    \let\@xmp@title\Hy@title
+    %\protected@xdef\@xmp@title{#1}%
+  \endgroup
+}
+\xmp@title{}%
+\let\@xmp@authors\@empty
+\let\@pdf@authors\@empty
+\begingroup\obeyspaces
+\gdef\xmp@author#1{%
+  \begingroup
+  \def~{ }%
+  \let\hack\@gobble
+  \def\nobreakspace{ }%
+  \protected@edef\@tempx{#1}%
+  \protected@xdef\@pdf@authors{\@pdf@authors\ifx\@pdf@authors\@empty\else, \fi\@tempx}%
+  \protected@xdef\@xmp@authors{\@xmp@authors              <rdf:li>\@tempx</rdf:li>^^J}%
+  \endgroup
+}
+\endgroup
 \thinmuskip=2mu
 \medmuskip=3mu minus 3mu
 \thickmuskip=4mu
@@ -104,6 +144,7 @@
   {\typeout{Additional configuration file copernicus.cfg used}}%
   {\CopernicusError{No additional configuration file copernicus.cfg}
                    {Please provide copernicus.cfg with the journal configurations.}}
+
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptions
 \if@stage@final\else\@twostagejnltrue\fi
@@ -375,10 +416,10 @@
       \rlap{\thepage}\hfil\@runhd}%
     \let\@oddfoot\@empty
     \let\@evenfoot\@empty
-    \if@cop@home\if@proof\else
-      \def\@oddfoot{\edit@rnotereminder\runningheaderfont\if@preface \@journalurlInfo\hfil Preface\else\@journalurlInfo\hfil\ifx\specialp@perstring\@undefined\@journalInfo\else\specialp@perstring\fi\fi}
-      \def\@evenfoot{\edit@rnotereminder\runningheaderfont\if@preface Preface\hfil\@journalurlInfo\else\ifx\specialp@perstring\@undefined\@journalInfo\else\specialp@perstring\fi\hfil\@journalurlInfo\fi}
-    \fi\fi
+    \if@cop@home
+      \def\@oddfoot{\if@proof\else\edit@rnotereminder\runningheaderfont\if@preface \@journalurlInfo\hfil Preface\else\@journalurlInfo\hfil\ifx\specialp@perstring\@undefined\@journalInfo\else\specialp@perstring\fi\fi\fi}
+      \def\@evenfoot{\if@proof\else\edit@rnotereminder\runningheaderfont\if@preface Preface\hfil\@journalurlInfo\else\ifx\specialp@perstring\@undefined\@journalInfo\else\specialp@perstring\fi\hfil\@journalurlInfo\fi\fi}
+    \fi
     \let\@mkboth\@gobbletwo}
 \else%discussions
   \def\ps@headings{%
@@ -474,7 +515,11 @@
   \clearpage
   \addtocounter{page}{-1}%
   \immediate\write\@auxout{\string\newlabel{LastPage}{{}{\thepage}{}{}{}}}%
-  \addtocounter{page}{1}}
+  \addtocounter{page}{1}%
+  %\@create@xmp{\@xmp@preamble \@xmp@postamble}%
+}
+\AtBeginDocument{%
+}
 \if@stage@final
   \def\@lpage{\hypersetup{linkcolor=textcol}\pageref{LastPage}}
 \else
@@ -487,6 +532,16 @@
 \def\@runtest{%
   \if@noauthor\else\if!\@runauth!\UndefinedError{\string\runningauthor}\fi\fi
   \if!\@runtit!\UndefinedError{\string\runningtitle}\fi}
+\let\ltx@title\title
+\ifx\xmltexversion\@undefined
+  \ifcopyediting
+    \let\title\ltx@title
+  \else
+    \def\title#1{\ltx@title{#1}\hypersetup{pdftitle=\@title}\xmp@title{#1}}
+  \fi
+\else
+  \def\title#1{\ltx@title{#1}\xmp@title{#1}}
+\fi
 \def\maketitle{%
   \gdef\supplement##1{%
     \href{https://doi.org/10.5194/\@journalnameshortlower-\@pvol-\@fpage-\@pyear-supplement}%
@@ -827,8 +882,10 @@
     \global\@topnum\z@
     \if@cop@home\ifonline
       \hypertarget{title}{}%
-      \hypersetup{pdfauthor={\@runauth}}%
-      \hypersetup{pdftitle={\@runtit}}%
+      \hypersetup{pdftitle={\@xmp@title}}%
+      \hypersetup{pdfauthor={\@pdf@authors}}%
+      % \hypersetup{pdfauthor={\@runauth}}%
+      % \hypersetup{pdftitle={\@runtit}}%
     \fi\fi
     \begin{nolinenumbers}%
     \if@cop@home
@@ -1234,8 +1291,12 @@
 \RequirePackage[T1]{fontenc}
 \RequirePackage{textcomp}
 \if@cop@home
-  \RequirePackage{fontawesome5}
-  \RequirePackage{fontawesome}
+    \RequirePackage{fontawesome5}
+    \ifluatex
+      %% TODO
+    \else
+      \RequirePackage{fontawesome}
+    \fi
 \fi
 \usepackage{upquote}%% #7510
 \usepackage{regexpatch}
@@ -1264,12 +1325,21 @@
 \endgroup
 \fi
 \ifx\xmltexversion\@undefined
-  \RequirePackage[utf8]{inputenc}
+  \ifluatex\else\RequirePackage[utf8]{inputenc}\fi
   \def\strip@x#1x#2\@nil{#1}%
   \IfFileExists{ucharacters.sty}{%
-    \def\DefineCharacter##1##2##3{\expandafter\def\expandafter\@argii\expandafter{\strip@x##2x\@nil}\DeclareUnicodeCharacter{\@argii}{##3}}%
-    \usepackage{ucharacters}%
-  }{}%
+    \ifluatex
+      % \RequirePackage{luacode}
+      % \def\DefineCharacter##1##2##3{%
+      %   \expandafter\def\expandafter\@argii\expandafter{\strip@x##2x\@nil}%
+      %   \begingroup\lccode`|=\string"\@argii\relax
+      %     \lowercase{\endgroup\newunicodechar{|}}{##3}}%
+      % \usepackage{ucharacters}%
+    \else
+      \def\DefineCharacter##1##2##3{\expandafter\def\expandafter\@argii\expandafter{\strip@x##2x\@nil}\DeclareUnicodeCharacter{\@argii}{##3}}%
+      \usepackage{ucharacters}%
+    \fi
+    }{}%
 \fi
 \def\cmrng{{\fontfamily{cmr}\selectfont\ng}}
 \let\old@classoptionslist\@classoptionslist
@@ -1340,7 +1410,7 @@
   \def\ercavailabilityname{Executable research compendium (ERC)}%
   \def\codedataavailabilityname{Code- und Datenverfügbarkeit}%
   \def\sampleavailabilityname{Probenverfügbarkeit}%
-  \def\authorcontributionname{Autorenmitwirkung}%
+  \def\authorcontributionname{Autor:innenmitwirkung}%
   \def\competinginterestsname{Interessenkonflikt}%
   \def\videosupplementname{Videoanhang}%
   \def\dosupplementname{Supplement}%
@@ -1473,7 +1543,11 @@
 
 \renewcommand\author[2][]%
       {\ifnewaffil\addtocounter{affil}{1}%
-       \xdef\AB@thenote{\arabic{affil}}\fi
+          \xdef\AB@thenote{\arabic{affil}}%
+       \fi
+       \ifcopyediting\else
+         \xmp@author{#2}%
+       \fi
        \global\advance\c@authnum\@ne
        \if@cop@home
          \expandafter\ifx\csname deceased@\the\c@authnum\endcsname\true\relax\def\@@deceased{$^{,\text{\faCross}}$}\fi
@@ -1581,10 +1655,10 @@
 \def\@@@Author(#1)#2#3{%
   \def\@tempc{#1}%
   \protected@edef\@tempd{%
-     \ifx\@tempb\@empty\else\@tempb\nobreakspace\fi
-     #2\nobreakspace
+     \ifx\@tempb\@empty\else\@tempb\noexpand\nobreakspace\fi
+     #2\noexpand\nobreakspace
      #3%
-     \ifx\@tempc\@empty\else\nobreakspace\@tempc\fi}%
+     \ifx\@tempc\@empty\else\noexpand\nobreakspace\@tempc\fi}%
   \expandafter\expandafter\expandafter\author\expandafter\expandafter\expandafter
     [\expandafter\@tempa\expandafter]\expandafter{\@tempd}}
 \providecommand\appendixname{Appendix}
@@ -1690,7 +1764,7 @@
   {\CopernicusWarningNoLine{Cannot find url.sty; proceeding without it}%
    \def\url#1{%
      \CopernicusError{To use \string\url, you must have url.sty}{Install url.sty}}}
-\newcommand\doitext{https://doi.org/}
+\newcommand\doitext{\hbox{https://doi.org/}}
 \newcommand*\doi{%
   \begingroup
   \lccode`\~=`\#\relax
@@ -1833,6 +1907,8 @@
   numberstyle=\footnotesize,%
   frame=lines,%
   xleftmargin=\dimexpr\listingnumwidth+0.5em\relax,%
+  %showspaces=true,
+  keepspaces=true,
   framexleftmargin=\dimexpr\listingnumwidth+0.5em\relax,
 }
 \newenvironment{listing}[1][]
@@ -1844,6 +1920,29 @@
     \expandafter\@tempa\expandafter[\@argi]}
  {\end{figure}%
   \setfigures}
+
+ % \gdef\xml@preformat@content#1{%
+ %   \begingroup
+ %     \utfeight@protect@internal
+ %     \nfss@catcodes
+ %     \xdef\x{\endgroup\noexpand\gdef\noexpand\xml@@preformat@content{#1}}\x
+ % }
+
+ % \begingroup
+ %   \XML@reset
+ %   \gdef\xml@lstlisting#1{%
+ %     \xml@preformat@content{#1}%
+ %     \message{^^J==> xml@preformat@content: \meaning\xml@@preformat@content}%
+ %     \begingroup
+ %       \XML@reset
+ %       \edef\@tempa{\noexpand\lstlisting[\@lstlistingArgument]}%
+ %       \expandafter\@tempa\xml@@preformat@content
+ %       \endlstlisting
+ %     \endgroup
+ %   }
+ % \endgroup
+
+
 \IfFileExists{subfloat.sty}
   {\RequirePackage{subfloat}%
    \protected@xdef\themainfigure{\thefigure}%
@@ -1867,6 +1966,7 @@
      \let\NAT@set@cites\relax
    \fi
    \AtBeginDocument{\let\@citex\NAT@citex}
+   \ifx\AddToHook\@undefined\else\AddToHook{begindocument/end}[copernicus/natbib]{\let\@citex\NAT@citex}\fi
    \newcommand\urlprefix{}
    \renewenvironment{thebibliography}[1]
    {\bibsection
@@ -1980,9 +2080,11 @@
     \provide@orig@symbol{Phi}
     \provide@orig@symbol{Psi}
     \provide@orig@symbol{Omega}
-    %% Fix fuer #6924, vgl https://tex.stackexchange.com/questions/561236/setmathalphabet-messes-with-rm
     \usepackage{etoolbox}%
-    \patchcmd\document@select@group{#1{#4}}{\expandafter#1\ifx\math@bgroup\bgroup{#4}\else#4\fi}{}{\fail}%
+    \ifluatex\else
+      %% Fix fuer #6924, vgl https://tex.stackexchange.com/questions/561236/setmathalphabet-messes-with-rm
+      \@iflatexlater{2020/10/01}{}{\patchcmd\document@select@group{#1{#4}}{\expandafter#1\ifx\math@bgroup\bgroup{#4}\else#4\fi}{}{}}%
+    \fi
     \RequirePackage[mtbold]{mathtime}
     \DeclareSymbolFont{largesymbolsA}{U}{esint}{m}{n}%from esint.sty
     \DeclareMathSymbol{\oiintop}{\mathop}{largesymbolsA}{'015}%from esint.sty
@@ -2093,19 +2195,52 @@
     \if@stage@final\else
       \PassOptionsToPackage{pagebackref,pdffitwindow}{hyperref}
     \fi
-    \usepackage[\ifcopyediting bookmarks=false\else bookmarks=true\fi,colorlinks]{hyperref}
-    \hypersetup{anchorcolor=black,citecolor=black,filecolor=black,linkcolor=black,%
-      menucolor=black,pagecolor=black,urlcolor=black}
+    %\@pdfa@pre@hyper
+    \@iflatexlater{2020/10/01}{%
+      \usepackage[bookmarks=true,colorlinks]{hyperref}
+      \hypersetup{anchorcolor=black,citecolor=black,filecolor=black,linkcolor=black,unicode,%
+        menucolor=black,urlcolor=black}%%
+    }{%
+      \usepackage[\ifcopyediting bookmarks=false\else bookmarks=true\fi,colorlinks]{hyperref}
+      \hypersetup{anchorcolor=black,citecolor=black,filecolor=black,linkcolor=black,%
+        menucolor=black,pagecolor=black,urlcolor=black}
+    }%
     \let\old@Hy@backout\Hy@backout\def\Hy@backout{\leavevmode\old@Hy@backout}%bug-fixing, to be checked
     \ifnum\pdfoutput=\z@\RequirePackage{breakurl}\fi
     \pdfstringdefDisableCommands{\let\boldsymbol\relax\let\vec\relax}
   \fi
   \edef\@pdfcreator{%
     copernicus.cls%
-    \space version \csname ver@copernicus.cls\endcsname
+    \space Version \csname ver@copernicus.cls\endcsname
     \ifx\xmltexversion\@undefined\else, produced from XML\fi}
-  \if@nohyperref\pdfinfo{/Creator (\@pdfcreator)}\fi
+  % \if@nohyperref
+  \AtEndDocument{%
+    \ifx\xmltexversion\@undefined
+      \ifluatex
+        \def\Hy@tempx{\pdfextension info}
+      \else
+        \def\Hy@tempx{\pdfinfo}
+      \fi%
+      \let\Hy@author\@pdf@authors\Hy@UseMaketitleString{author}%
+      \let\Hy@title\@xmp@title\Hy@UseMaketitleString{title}%
+      \ifx\@xmp@keywords\@empty\else
+        \let\Hy@keywords\@xmp@keywords\Hy@UseMaketitleString{keywords}%
+      \fi
+      \Hy@tempx{%
+        /Title (\@pdftitle)
+        /Author (\@pdfauthor)
+        \ifx\@pdfkeywords\@empty\else/Keywords (\@pdfkeywords)\fi
+        /Creator (\@pdfcreator)
+      }%
+    \else
+      % \protected@edef\@pdftitle{\xml@pdftitle}%
+      % \protected@edef\@pdfauthor{\@pdf@authors}%
+      % \ifx\@keywords\@undefined\else\protected@edef\@pdfkeywords{\@keywords}\fi%
+    \fi
+  }%
+  % \fi
 \else
+  %\@pdfa@pre@hyper
   \usepackage[bookmarks=false,pdfborder={0 0 0}]{hyperref}
   \pdfstringdefDisableCommands{\let\boldsymbol\relax\let\vec\relax}
 \fi
@@ -2197,10 +2332,16 @@
       \setlength\footskip{5mm}%because pdfscreencop overwrites it
       \def\addButton#1#2{\begingroup\normalsfcodes\fboxsep\z@
         \sffamily\colorbox{buttonbackground}{\hbox to#1{\hfil\Black\st#2\hfil}}\endgroup}
-      \hypersetup{anchorcolor=black,citecolor=black,filecolor=black,linkcolor=black,%
-                  menucolor=black,pagecolor=black,urlcolor=black,%
-                  pdfcenterwindow=false,pdfmenubar=true,pdftoolbar=true,pdfwindowui=true}
-                 %because pdfscreencop overwrites it
+      \@iflatexlater{2020/10/01}{%
+        \hypersetup{anchorcolor=black,citecolor=black,filecolor=black,linkcolor=black,%
+                    menucolor=black,urlcolor=black,%
+                    pdfcenterwindow=false,pdfmenubar=true,pdftoolbar=true,pdfwindowui=true}%%
+      }{%
+        \hypersetup{anchorcolor=black,citecolor=black,filecolor=black,linkcolor=black,%
+                    menucolor=black,pagecolor=black,urlcolor=black,%
+                    pdfcenterwindow=false,pdfmenubar=true,pdftoolbar=true,pdfwindowui=true}
+      }%
+      % because pdfscreencop overwrites it
       \def\PDFSCR@Warning#1{}% no more "No overlay specified" warnings
       \setlength\panelwidth{5cm}%
       \newlength\bigbutton\setlength\bigbutton{0.75\panelwidth}%
@@ -2390,10 +2531,14 @@
   \def\@pvol{0}
 \fi
 \if@stage@final
-  \def\keywords#1{\def\@keyw{#1}}
+  \def\keywords#1{%
+    \ifcopyediting\else\xmp@keywords{#1}\fi%
+    \def\@keyw{#1}%
+  }
   \def\@keyw{}
 \else
   \def\keywords#1{%
+    \ifcopyediting\else\xmp@keywords{#1}\fi%
     \CopernicusWarningNoLine{Keywords are not supported.}%
     \vspace{1.7mm}\par\noindent\textbf{Keywords.}\enspace\ignorespaces#1}
 \fi
@@ -2733,8 +2878,7 @@
 \newcommand\@sentenceDisc{Sentence.}
 \def\watermark{%
   \smash{\rlap{%
-      \fontsize{120}{120}\selectfont
-      \lower.75\textheight\hbox{\hskip10mm\rotatebox{36}{\rmfamily\textcolor{watermark}{Proof only}}}%
+      \lower\dimexpr\paperheight-\headheight-\topmargin\relax\hbox{\hskip-\oddsidemargin\includegraphics{cop_watermark.pdf}}%
     }}
 }
 \if@stage@final
@@ -2762,42 +2906,54 @@
   \edef\@journalnameshort{\@journalnameshort D}
   \edef\@journalnameshortlower{\@journalnameshortlower d}
 \fi
+\def\bElementCitation{}
+\def\bUri#1{#1}
 \def\bDate#1{#1}
 \def\bYear#1{#1}
 \def\bMonth#1{#1}
 \def\bDay#1{#1}
-\def\bPubId#1{#1}
+\def\bPubId{}
 \def\bLpage#1{#1}
 \def\bFpage#1{#1}
 \def\bPersonGroup#1{#1}
+\def\bPersonGroup#1{#1}
+\def\bName#1{#1}
 \def\bName#1{#1}
 \def\bCollab#1{#1}
+\def\bCollab#1{#1}
 \def\bSurname#1{#1}
-\def\bParticle#1{#1}
-\def\bSuffix#1{#1}
-\def\bELocationID#1{#1}
+\def\bSurname#1{#1}
 \def\bGivenNames#1{#1}
+\def\bSuffix#1{#1}
+\def\bSuffix#1{#1}
+\def\bParticle#1{#1}
+\def\bParticle#1{#1}
 \def\bVolume#1{#1}
 \def\bIssue#1{#1}
 \def\bSource#1{#1}
-\let\bUri\url
-\def\bArticleTitle#1{#1}
+\def\bSource#1{#1}
 \def\bChapterTitle#1{#1}
+\def\bComment#1{#1}
+\def\bArticleTitle#1{#1}
+\def\bSource#1{#1}
+\def\bChapterTitle#1{#1}
+\def\bSource#1{#1}
 \def\bEtal#1{#1}
-\def\bElementCitation#1{#1}
+\def\bEtal#1{#1}
 \def\bPublisherName#1{#1}
 \def\bPublisherLoc#1{#1}
 \def\bIsbn#1{#1}
+\def\bDateInCitation#1{#1}
 \def\bDateInCitation#1{#1}
 \def\bEdition#1{#1}
 \def\bConfName#1{#1}
 \def\bConfLoc#1{#1}
 \def\bConfDate#1{#1}
 \def\bComment#1{#1}
-\def\bPatent{\@ifnextchar [\@bPatent{\@bPatent[]}}%]
-\def\@bPatent[#1]#2{#2}
+\def\bPatent#1{#1}
 \def\bSeries#1{#1}
 \def\bStd#1{#1}
+\def\bELocationID#1{#1}
 \def\bAttribute#1#2{}
  %% LEGACY
  \def\Etal#1{#1}

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -57,7 +57,7 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.7, 16 March 2022, using \code{copernicus.cls} in version 9.46, 25 March  2022.
+\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.9, 26 September 2022, using \code{copernicus.cls} in version 9.46, 25 March 2022.
 
 \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 

--- a/man/copernicus_article.Rd
+++ b/man/copernicus_article.Rd
@@ -57,7 +57,7 @@ This was adapted from
 
 An number of required and optional manuscript sections, e.g. \code{acknowledgements}, \code{competinginterests}, or \code{authorcontribution}, must be declared using the respective properties of the R Markdown header - see skeleton file.
 
-\strong{Version:} Based on \code{copernicus_package.zip} in the version 6.9, 26 September 2022, using \code{copernicus.cls} in version 9.46, 25 March 2022.
+\strong{Version:} Based on \code{copernicus_package.zip} in the version 7.1, 06 December 2022, using \code{copernicus.cls} in version 10.1.4, 06 December 2022.
 
 \strong{Copernicus journal abbreviations:} You can use the function \code{copernicus_journal_abbreviations()} to get the journal abbreviation for all journals supported by the Copernicus article template.
 


### PR DESCRIPTION
Another update to the newest Copernicus template version from September 26 2022.
@nuest 

- [X] Update Rd and namespace (could be done by `devtools::document()`).

- [X] Update NEWS.

- [X] Update README with a link to the newly supported journal. Please add your Github username and the full name of the journal (follow other examples in the list). 
