### PR TITLE
Support affiliation fields like elsevier template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rticles
 Title: Article Formats for R Markdown
-Version: 0.24.7
+Version: 0.24.8
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## MINOR CHANGES
 
+- Improve `elsevier_article()` affilliations for authors by supporting same fields as in official template. This also fix address with comma not showing (thanks, @gjpstrain, @mps9506, #509).
+
 - Update `RJournal.sty` to latest version to support number sections (thanks, @zeileis, #517).
 
 - Update to the `asa_article()` format (thanks, @ianmtaylor1 #506, @jepusto, #507):

--- a/inst/rmarkdown/templates/elsevier/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier/resources/template.tex
@@ -198,7 +198,14 @@ $endfor$
   $if(author.email)$ \ead{$author.email$} $endif$
   $endfor$
   $for(address)$
-  \affiliation[$address.code$]{$address.address$}
+  \affiliation[$address.code$]{$if(address.address)$$address.address$$else$
+    $if(address.organization)$organization={$address.organization$},$endif$
+    $if(address.addressline)$addressline={$address.addressline$},$endif$
+    $if(address.city)$city={$address.city$},$endif$
+    $if(address.postcode)$postcode={$address.postcode$},$endif$
+    $if(address.state)$state={$address.state$},$endif$
+    $if(address.country)$country={$address.country$},$endif$
+    $endif$}
   $endfor$
   \cortext[cor1]{Corresponding author}
   $for(footnote)$

--- a/inst/rmarkdown/templates/elsevier/resources/template.tex
+++ b/inst/rmarkdown/templates/elsevier/resources/template.tex
@@ -199,13 +199,7 @@ $endfor$
   $endfor$
   $for(address)$
   \affiliation[$address.code$]{$if(address.address)$$address.address$$else$
-    $if(address.organization)$organization={$address.organization$},$endif$
-    $if(address.addressline)$addressline={$address.addressline$},$endif$
-    $if(address.city)$city={$address.city$},$endif$
-    $if(address.postcode)$postcode={$address.postcode$},$endif$
-    $if(address.state)$state={$address.state$},$endif$
-    $if(address.country)$country={$address.country$},$endif$
-    $endif$}
+    $if(address.organization)$organization={$address.organization$},$endif$$if(address.addressline)$addressline={$address.addressline$},$endif$$if(address.city)$city={$address.city$},$endif$$if(address.postcode)$postcode={$address.postcode$},$endif$$if(address.state)$state={$address.state$},$endif$$if(address.country)$country={$address.country$},$endif$$endif$}
   $endfor$
   \cortext[cor1]{Corresponding author}
   $for(footnote)$

--- a/inst/rmarkdown/templates/elsevier/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/elsevier/skeleton/skeleton.Rmd
@@ -19,7 +19,13 @@ author:
     footnote: 2
 address:
   - code: Some Institute of Technology
-    address: Department, Street, City, State, Zip
+    address: 
+      organization: Big Wig University
+      addressline: 1 main street
+      city: Gotham
+      state: State
+      postcode: 123456
+      country: United States
   - code: Another University
     address: Department, Street, City, State, Zip
 footnote:


### PR DESCRIPTION
This closes #509 by correctly supporting affiliation fields as explained in the doc and template 
* https://www.elsevier.com/authors/policies-and-guidelines/documents/elsdoc-1.pdf
* https://ctan.crest.fr/tex-archive/macros/latex/contrib/elsarticle/elsarticle-template-harv.tex

````latex
%% use optional labels to link authors explicitly to addresses:
%% \author[label1,label2]{}
%% \affiliation[label1]{organization={},
%%             addressline={},
%%             city={},
%%             postcode={},
%%             state={},
%%             country={}}
%%
%% \affiliation[label2]{organization={},
%%             addressline={},
%%             city={},
%%             postcode={},
%%             state={},
%%             country={}}
````

the skeleton has been updated to show how to pass affiliation either using the fields or using raw latex. Passing a simple string like 
```
  - code: Another University
    address: Department, Street, City, State, Zip
```

was not showing the comma in the output (it would probably need to be escaped)