### PR TITLE
Support multiple institution for author in wide format for IEEE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rticles
 Title: Article Formats for R Markdown
-Version: 0.24.8
+Version: 0.24.9
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `ajs_article()` and `jss_article()` require Pandoc 2.7+ (possibly required by some changes in `jss.cls`)
 
+## NEW FEATURES
+
+- `ieee_article()` now supports several affiliations per `authors` when using the `wide: true` mode (thanks, @phamdn, #500)
+
 ## MINOR CHANGES
 
 - Improve `elsevier_article()` affilliations for authors by supporting same fields as in official template. This also fix address with comma not showing (thanks, @gjpstrain, @mps9506, #509).

--- a/inst/rmarkdown/templates/ieee/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee/resources/template.tex
@@ -509,12 +509,10 @@ $endif$ %%$-- end if/affiliation.institution-columnar
 
 
 %% ---- one column per author, classic/default IEEETrans ----
-$if(affiliation.author-columnar)$ % -- beg affiliation.author-columnar
+$if(affiliation.author-columnar)$
 $for(affiliation.institution)$
-$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
-\IEEEauthorblockN{
-$affiliation.institution.author.name$
-}
+$for(affiliation.institution.author)$
+\IEEEauthorblockN{$affiliation.institution.author.name$}
 \IEEEauthorblockA{$affiliation.institution.name$\\
 $if(affiliation.institution.department)$
 $affiliation.institution.department$\\
@@ -523,18 +521,18 @@ $affiliation.institution.location$
 $if(affiliation.institution.email)$
 \\$affiliation.institution.email$
 $else$
-$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
+$for(affiliation.institution.author)$
 $if(affiliation.institution.author.email)$
 \\$affiliation.institution.author.email$
 $endif$
-$endfor$ %% -- end for/affiliation.institution.author
+$endfor$%%$-- end for/affiliation.institution.author
 $endif$
 }
 $sep$\and
-$endfor$ %% -- end for/affiliation.institution.author
+$endfor$$-- end for/affiliation.institution.author
 $sep$\and
-$endfor$ %% -- end for/affiliation.institution
-$endif$ %% -- end if/affiliation.institution-columnar
+$endfor$$-- end for/affiliation.institution
+$endif$$-- end if/affiliation.institution-columnar
 %% ----------------------------------------------------------
 
 $endif$

--- a/inst/rmarkdown/templates/ieee/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee/resources/template.tex
@@ -489,31 +489,19 @@ $endfor$$endif$$-- end for/affiliation.institution and end if affiliation.wide
 %% ----------------------------------------------------------
 
 %% ---- classic IEEETrans one column per institution --------
-$if(affiliation.institution-columnar)$ %% -- beg if/affiliation.institution-columnar
+$if(affiliation.institution-columnar)$
 $for(affiliation.institution)$
-\IEEEauthorblockN{
-$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
-$affiliation.institution.author.name$$sep$,
-$endfor$ %% -- end for/affiliation.institution.author
-}
-\IEEEauthorblockA{$if(affiliation.institution.department)$
-$affiliation.institution.department$\\
-$endif$
+\IEEEauthorblockN{$for(affiliation.institution.author)$$affiliation.institution.author.name$$sep$, $endfor$}
+\IEEEauthorblockA{
+$if(affiliation.institution.department)$$affiliation.institution.department$\\$endif$%%
 $affiliation.institution.name$\\
 $affiliation.institution.location$
-$if(affiliation.institution.email)$
-\\$affiliation.institution.email$
-$else$
-$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
-$if(affiliation.institution.author.email)$
-\\$affiliation.institution.author.email$
-$endif$
-$endfor$ %% -- end for/affiliation.institution.author
-$endif$
+$if(affiliation.institution.email)$\\$affiliation.institution.email$$else$$for(affiliation.institution.author)$$if(affiliation.institution.author.email)$\\$affiliation.institution.author.email$$endif$$endfor$%%
+$endif$%%$-- end for/affiliation.institution.author
 }
 $sep$\and
-$endfor$ %% -- end for/affiliation.institution
-$endif$ %% -- end if/affiliation.institution-columnar
+$endfor$ %%$-- end for/affiliation.institution
+$endif$ %%$-- end if/affiliation.institution-columnar
 %% ----------------------------------------------------------
 
 

--- a/inst/rmarkdown/templates/ieee/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee/resources/template.tex
@@ -461,7 +461,7 @@ $if(affiliation.wide)$
 \IEEEauthorblockN{
 $if(affiliation.author)$
 $for(affiliation.author)$
-$affiliation.author.name$\IEEEauthorrefmark{$affiliation.author.mark$}$sep$,
+$affiliation.author.name$$for(affiliation.author.mark)$\IEEEauthorrefmark{$affiliation.author.mark$}$endfor$$sep$,
 $endfor$
 $else$ $-- else affiliation.author
 $if(affiliation.author_multiline)$

--- a/inst/rmarkdown/templates/ieee/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee/resources/template.tex
@@ -463,28 +463,28 @@ $if(affiliation.author)$
 $for(affiliation.author)$
 $affiliation.author.name$\IEEEauthorrefmark{$affiliation.author.mark$}$sep$,
 $endfor$
-$else$
+$else$ $-- else affiliation.author
 $if(affiliation.author_multiline)$
 $for(affiliation.author_multiline)$
 $for(affiliation.author_multiline.line)$
 $affiliation.author_multiline.line.name$\IEEEauthorrefmark{$affiliation.author_multiline.line.mark$}
 $sep$,
-$endfor$
+$endfor$ $-- end affiliation.author_multiline.line
 $sep$}\IEEEauthorblockN{
-$endfor$
-$else$
+$endfor$ $-- end affiliation.author_multiline
+$else$ $-- else affiliation.author_multiline
 $for(affiliation.institution)$ %% -- beg for/affiliation.institution
 $for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
 $affiliation.institution.author.name$\IEEEauthorrefmark{$affiliation.institution.mark$}
 $sep$,
-$endfor$ %% -- end for/affiliation.institution.author
+$endfor$ $-- end for/affiliation.institution.author
 $sep$,
-$endfor$ %% -- end for/affiliation.institution
-$endif$
-$endif$
+$endfor$ $-- end for/affiliation.institution
+$endif$ $-- end affiliation.author_multiline
+$endif$ $-- end affiliation.author
 }
 
-$for(affiliation.institution)$ %% -- beg for/affiliation.institution
+$for(affiliation.institution)$
 \IEEEauthorblockA{\IEEEauthorrefmark{$affiliation.institution.mark$}
 $if(affiliation.institution.department)$
 $affiliation.institution.department$\\
@@ -495,8 +495,8 @@ $if(affiliation.institution.email)$
 \\ $affiliation.institution.email$
 $endif$
 }
-$endfor$ %% -- end for/affiliation.institution
-$endif$ % -- end affiliation.wide
+$endfor$ $-- end for/affiliation.institution
+$endif$ $-- end affiliation.wide
 %% ----------------------------------------------------------
 
 

--- a/inst/rmarkdown/templates/ieee/resources/template.tex
+++ b/inst/rmarkdown/templates/ieee/resources/template.tex
@@ -459,29 +459,19 @@ $if(affiliation)$
 %% ---- classic IEEETrans wide authors' list ----------------
 $if(affiliation.wide)$
 \IEEEauthorblockN{
-$if(affiliation.author)$
-$for(affiliation.author)$
-$affiliation.author.name$$for(affiliation.author.mark)$\IEEEauthorrefmark{$affiliation.author.mark$}$endfor$$sep$,
-$endfor$
-$else$ $-- else affiliation.author
-$if(affiliation.author_multiline)$
-$for(affiliation.author_multiline)$
+$if(affiliation.author)$$for(affiliation.author)$
+$affiliation.author.name$$for(affiliation.author.mark)$\IEEEauthorrefmark{$affiliation.author.mark$}$endfor$$sep$,$endfor$
+$else$%% $-- else affiliation.author
+$if(affiliation.author_multiline)$$for(affiliation.author_multiline)$
 $for(affiliation.author_multiline.line)$
-$affiliation.author_multiline.line.name$\IEEEauthorrefmark{$affiliation.author_multiline.line.mark$}
-$sep$,
-$endfor$ $-- end affiliation.author_multiline.line
-$sep$}\IEEEauthorblockN{
-$endfor$ $-- end affiliation.author_multiline
-$else$ $-- else affiliation.author_multiline
-$for(affiliation.institution)$ %% -- beg for/affiliation.institution
-$for(affiliation.institution.author)$  %% -- beg for/affiliation.institution.author
-$affiliation.institution.author.name$\IEEEauthorrefmark{$affiliation.institution.mark$}
-$sep$,
-$endfor$ $-- end for/affiliation.institution.author
-$sep$,
-$endfor$ $-- end for/affiliation.institution
-$endif$ $-- end affiliation.author_multiline
-$endif$ $-- end affiliation.author
+$affiliation.author_multiline.line.name$$for(affiliation.author_multiline.line.mark)$\IEEEauthorrefmark{$affiliation.author_multiline.line.mark$}$endfor$$sep$,
+$endfor$$-- end affiliation.author_multiline.line
+$sep$}
+\IEEEauthorblockN{
+$endfor$$else$%%$-- end for affiliation.author_multiline and else affiliation.author_multiline
+$for(affiliation.institution)$$for(affiliation.institution.author)$
+$affiliation.institution.author.name$\IEEEauthorrefmark{$affiliation.institution.mark$}$sep$,$endfor$$-- end for/affiliation.institution.author
+$sep$,$endfor$$endif$$endif$%%$-- end for/affiliation.institution and end if affiliation.author_multiline and affiliation.author
 }
 
 $for(affiliation.institution)$
@@ -495,11 +485,8 @@ $if(affiliation.institution.email)$
 \\ $affiliation.institution.email$
 $endif$
 }
-$endfor$ $-- end for/affiliation.institution
-$endif$ $-- end affiliation.wide
+$endfor$$endif$$-- end for/affiliation.institution and end if affiliation.wide
 %% ----------------------------------------------------------
-
-
 
 %% ---- classic IEEETrans one column per institution --------
 $if(affiliation.institution-columnar)$ %% -- beg if/affiliation.institution-columnar

--- a/inst/rmarkdown/templates/ieee/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ieee/skeleton/skeleton.Rmd
@@ -1,23 +1,36 @@
 ---
 title: Bare Demo of IEEEtran.cls for IEEE Conferences
 affiliation:
-  ## use one only of the following
-  # author-columnar: true         ## one column per author
-  institution-columnar: true  ## one column per institution (multiple autors eventually)
-  # wide: true                  ## one column wide author/affiliation fields
-
-  #author:   ## A custom author ordering field that breaks institution grouping.
-  #  - name: Eldon Tyrell
-  #    mark: 4
-  #    email: eldon@starfleet-academy.star
-  #  - name: Michael Shell
-  #    mark: 1
-  #  - name: Roy Batty
-  #    mark: 4
-  #    email: roy@replicant.offworld
-  ## Authors cited in institution field are ignored when author field exists
-
-  #author_multiline: ## Put authors in a given order, with multiline possibility. Authors cited in institution are ignored if exists
+  ## Author mode :  use one only of the following --- +
+  
+  ## one column per author - using only the institution field
+  # author-columnar: true # uncomment this line to use
+  
+  ## one column per institution - using only the institution field
+  # institution-columnar: true # uncomment this line to use
+  
+  ## one column wide author/affiliation fields - using author or author_multiline and institution for mark
+  wide: true # uncomment this line to use
+  
+  ## Author mode: End ----
+  
+  ## A custom author ordering field that breaks institution grouping (used with `wide: true`)
+  ## Authors cited in institution field are ignored when this author field exists
+  ## Comment / Uncomment below
+  author:   
+   - name: Eldon Tyrell
+     mark: [2, 3]
+     email: eldon@starfleet-academy.star
+   - name: Michael Shell
+     mark: 1
+   - name: Roy Batty
+     mark: 4
+     email: roy@replicant.offworld
+  
+  ## Put authors in a given order, with multiline possibility (used with `wide: true` if `authors` above unset)
+  ## Authors cited in institution are ignored if exists
+  ## Comment / Uncomment below
+  #author_multiline: 
   #  - line:         ## Create a new author line
   #    - name: Michael Shell
   #      mark: 1
@@ -33,11 +46,12 @@ affiliation:
   #    - name: Eldon Tyrell
   #      mark: 4
 
+  ## Define institution, and also authors used when `author-columnar: true` or `institution-columnar: true`
   institution:
     - name: Georgia Institute of Technology
       department: School of Electrical and Computer Engineering
       location: Atlanta, Georgia 30332--0250
-      email: ece@datech.edu
+      email: ece@datech.edu # if unset, authors' email will be used
       mark: 1
       author:
         - name: Michael Shell
@@ -61,6 +75,7 @@ affiliation:
           email: eldon@starfleet-academy.star
         - name: Roy Batty
           email: roy@replicant.offworld
+
 keywords: ["keyword 1", "keyword 2"]
 abstract: |
   The abstract goes here.
@@ -80,8 +95,8 @@ output: rticles::ieee_article
 #citation_sorting: none   ## used as sorting option of the biblatex package (if selected)
 ---
 
-Introduction
-=============
+# Introduction
+
 <!-- no \IEEEPARstart -->
 This demo file is intended to serve as a ``starter file''
 for IEEE conference papers produced under \LaTeX\ using
@@ -89,7 +104,6 @@ IEEEtran.cls version 1.8b and later.
 <!-- You must have at least 2 lines in the paragraph with the drop letter
 (should never be an issue) -->
 I wish you the best of success.
-
 
 ## Subsection Heading Here
 Subsection text here.
@@ -192,22 +206,19 @@ footnotes above bottom floats. This can be corrected via the
 \fnbelowfloat command of the stfloats package. -->
 
 
-Conclusion
-============
+# Conclusion
+
 The conclusion goes here.
 
 <!-- conference papers do not normally have an appendix -->
 
-Acknowledgment {#acknowledgment}
-==============
+# Acknowledgment {#acknowledgment}
 
 The authors would like to thank...
 
-Bibliography styles
-===================
+# Bibliography styles
 
 Here are two sample references: @Feynman1963118 [@Dirac1953888].
 
 \newpage
-References {#references .numbered}
-==========
+# References {#references .numbered}


### PR DESCRIPTION
This should solve #500 to allow multiple affiliation using 
````yaml
  author:   
   - name: Eldon Tyrell
     mark: [2, 3]
     email: eldon@starfleet-academy.star
````

when `wide: true` is used. 

The template is also update for other mode