### PR TITLE
Fix equal contribution in Springer template and add ORCID ID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rticles
 Title: Article Formats for R Markdown
-Version: 0.27.1
+Version: 0.27.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rticles (development version)
 
+- Fix `springer_article()` skeleton: It now uses `equal_contribution` in author field (thanks, @nielsbock, #568).
+
 # rticles 0.27
 
 - `joss_article()` now correctly works as `base_format` for `bookdown::pdf_book()` (thanks, @mlysy, #564).

--- a/inst/rmarkdown/templates/springer/resources/template.tex
+++ b/inst/rmarkdown/templates/springer/resources/template.tex
@@ -30,6 +30,7 @@
 \usepackage{algorithmicx}%
 \usepackage{algpseudocode}%
 \usepackage{listings}%
+\usepackage{orcidlink}%
 %%%%
 
 %%%%%=============================================================================%%%%
@@ -195,8 +196,8 @@ $endfor$
 %%=============================================================%%
 
 $for(authors)$
-\author$if(authors.corresponding)$*$endif$[$for(authors.affiliation)$$authors.affiliation$$sep$,$endfor$]{$if(authors.prefix)$\pfx{$authors.prefix$} $endif$$if(authors.firstname)$\fnm{$authors.firstname$} $endif$$if(authors.particle)$\spfx{$authors.particle$} $endif$$if(authors.lastname)$\sur{$authors.lastname$} $endif$$if(authors.suffix)$\sfx{$authors.suffix$} $endif$$if(authors.naturename)$\tanm{$authors.naturename$} $endif$$if(authors.degrees)$\dgr{$authors.degrees$}$endif$}$if(authors.email)$\email{$authors.email$}$endif$
-$if(authors.equal_contribution)$\equalcont{authors.equal_contribution}$endif$
+\author$if(authors.corresponding)$*$endif$[$for(authors.affiliation)$$authors.affiliation$$sep$,$endfor$]{$if(authors.prefix)$\pfx{$authors.prefix$} $endif$$if(authors.firstname)$\fnm{$authors.firstname$} $endif$$if(authors.particle)$\spfx{$authors.particle$} $endif$$if(authors.lastname)$\sur{$authors.lastname$} $endif$$if(authors.suffix)$\sfx{$authors.suffix$} $endif$$if(authors.naturename)$\tanm{$authors.naturename$} $endif$$if(authors.degrees)$\dgr{$authors.degrees$}$endif$$if(authors.orcid)$~\orcidlink{$authors.orcid$}$endif$}$if(authors.email)$\email{$authors.email$}$endif$
+$if(authors.equal_contribution)$\equalcont{$authors.equal_contribution$}$endif$
 $endfor$
 
 

--- a/inst/rmarkdown/templates/springer/resources/template.tex
+++ b/inst/rmarkdown/templates/springer/resources/template.tex
@@ -196,7 +196,7 @@ $endfor$
 %%=============================================================%%
 
 $for(authors)$
-\author$if(authors.corresponding)$*$endif$[$for(authors.affiliation)$$authors.affiliation$$sep$,$endfor$]{$if(authors.prefix)$\pfx{$authors.prefix$} $endif$$if(authors.firstname)$\fnm{$authors.firstname$} $endif$$if(authors.particle)$\spfx{$authors.particle$} $endif$$if(authors.lastname)$\sur{$authors.lastname$} $endif$$if(authors.suffix)$\sfx{$authors.suffix$} $endif$$if(authors.naturename)$\tanm{$authors.naturename$} $endif$$if(authors.degrees)$\dgr{$authors.degrees$}$endif$$if(authors.orcid)$~\orcidlink{$authors.orcid$}$endif$}$if(authors.email)$\email{$authors.email$}$endif$
+\author$if(authors.corresponding)$*$endif$[$for(authors.affiliation)$$authors.affiliation$$sep$,$endfor$]{$if(authors.prefix)$\pfx{$authors.prefix$} $endif$$if(authors.firstname)$\fnm{$authors.firstname$} $endif$$if(authors.particle)$\spfx{$authors.particle$} $endif$$if(authors.lastname)$\sur{$authors.lastname$} $endif$$if(authors.suffix)$\sfx{$authors.suffix$} $endif$$if(authors.naturename)$\tanm{$authors.naturename$} $endif$$if(authors.degrees)$\dgr{$authors.degrees$}$endif$$if(authors.orcid)$\orcidlink{$authors.orcid$}$endif$}$if(authors.email)$\email{$authors.email$}$endif$
 $if(authors.equal_contribution)$\equalcont{$authors.equal_contribution$}$endif$
 $endfor$
 

--- a/inst/rmarkdown/templates/springer/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/springer/skeleton/skeleton.Rmd
@@ -27,15 +27,16 @@ authors:
     suffix: III
     naturename: Poet Laureate
     degrees: MSc, PhD
+    orcid: 0000-0000-0000-0000
     email: abc@def
     affiliation: [1,2]
     corresponding: TRUE
-    equalcont: These authors contributed equally to this work.
+    equal_contribution: These authors contributed equally to this work.
     
   - firstname: Second
     lastname: Author
     affiliation: 2
-    equalcont: These authors contributed equally to this work.
+    equal_contribution: These authors contributed equally to this work.
 
 
 affiliations:


### PR DESCRIPTION
Thank you for a providing and maintaining a this great package!

While using the Springer Template, I noticed that the equal contributions line on the fronpage was missing. I have corrected it and tested it in my pull request so it should work now. Further, I have added an option to include ORCID ID at the end of each author line. Ideally, the ORCID ID should be placed after the star and dagger, but doing that is beyond my abilities. Supplying ORCID is not specified in the Springer Nature Template guide; however, some Springer Journals, e.g. the European Journal of Nutrition, accept manuscript submissions based on the Springer Nature Template but also encourages authors to provide ORCID. So I think it makes sense to add it.

I hope these changes are useful. I'm quite new in this field (this is only my second pull request ever) so I hope I haven't messed anything up.

EUR J NUTR submission guidelines:
https://link.springer.com/journal/394/submission-guidelines#Instructions%20for%20Authors_Title%20Page