### PR TITLE
Fix oup_v1 render failure after upstream CTAN \authormark removal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rticles
 Title: Article Formats for R Markdown
-Version: 0.27.13
+Version: 0.27.14
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@ supported by the `copernicus.cls`, and fix an issue where the section headers we
   - Added `\setlength{\emergencystretch}{3em}` to prevent overfull lines.
   - Updated CSL citation helper commands (`\CSLBlock`, `\CSLLeftMargin`, `\CSLRightInline`) to match current Pandoc defaults, improving bibliography spacing and baseline alignment.
 
-- Fix `oup_article(oup_version = 1)` rendering with the November 2025 update of `oup-authoring-template.cls` (v1.2) on CTAN, which removed the (undocumented) `\authormark` macro that the template was emitting for the running head. The block is now dropped from the template, matching OUP's own example file and current author manual: the running head is set via the optional argument of `\title` (`\title[short]{long}`), which is the documented mechanism in v1.2 (#603).
+- Fix `oup_article(oup_version = 1)` rendering with the November 2025 update of `oup-authoring-template.cls` (v1.2) on CTAN, which removed the (undocumented) `\authormark` macro that the template was emitting for the running head. The block is now dropped from the template, matching OUP's own example file and current author manual: the running head is set via the optional argument of `\title` (`\title[short]{long}`), which is the documented mechanism in v1.2. Setting `authormark` in YAML is now ignored and emits a warning at render time (#603).
 
 - Adapt all templates to new Pandoc 3.8.2.1 change regarding table counter definition (#595).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@ supported by the `copernicus.cls`, and fix an issue where the section headers we
   - Added `\setlength{\emergencystretch}{3em}` to prevent overfull lines.
   - Updated CSL citation helper commands (`\CSLBlock`, `\CSLLeftMargin`, `\CSLRightInline`) to match current Pandoc defaults, improving bibliography spacing and baseline alignment.
 
+- Fix `oup_article(oup_version = 1)` rendering with the November 2025 update of `oup-authoring-template.cls` (v1.2) on CTAN, which removed the `\authormark` macro definition but still references it from the class' own `\@@title`. The template now defines a no-op `\authormark` fallback so documents render whether or not the upstream macro is available (#603).
+
 - Adapt all templates to new Pandoc 3.8.2.1 change regarding table counter definition (#595).
 
 - Patch `WileyNDJ` template used in `sim_article()` to fix an issue with `etex` package not being useful anymore in recent LaTeX distributions (#593).

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@ supported by the `copernicus.cls`, and fix an issue where the section headers we
   - Added `\setlength{\emergencystretch}{3em}` to prevent overfull lines.
   - Updated CSL citation helper commands (`\CSLBlock`, `\CSLLeftMargin`, `\CSLRightInline`) to match current Pandoc defaults, improving bibliography spacing and baseline alignment.
 
-- Fix `oup_article(oup_version = 1)` rendering with the November 2025 update of `oup-authoring-template.cls` (v1.2) on CTAN, which removed the `\authormark` macro definition but still references it from the class' own `\@@title`. The template now defines a no-op `\authormark` fallback so documents render whether or not the upstream macro is available (#603).
+- Fix `oup_article(oup_version = 1)` rendering with the November 2025 update of `oup-authoring-template.cls` (v1.2) on CTAN, which removed the (undocumented) `\authormark` macro that the template was emitting for the running head. The block is now dropped from the template, matching OUP's own example file and current author manual: the running head is set via the optional argument of `\title` (`\title[short]{long}`), which is the documented mechanism in v1.2 (#603).
 
 - Adapt all templates to new Pandoc 3.8.2.1 change regarding table counter definition (#595).
 

--- a/R/oup_article.R
+++ b/R/oup_article.R
@@ -126,7 +126,7 @@ oup_article <- function( # Controls template to use. 1 for newer template.
     }
   }
 
-  pdf_document_format(
+  base <- pdf_document_format(
     "oup_v1",
     keep_tex = keep_tex,
     md_extensions = md_extensions,
@@ -135,4 +135,20 @@ oup_article <- function( # Controls template to use. 1 for newer template.
     number_sections = number_sections,
     ...
   )
+
+  # Warn if YAML metadata still sets the removed `authormark` field
+  # (oup-authoring-template.cls v1.2, 2025-11-17, dropped the \authormark macro)
+  pre_knit <- base$pre_knit
+  base$pre_knit <- function(input, metadata, ...) {
+    if (is.function(pre_knit)) pre_knit(input, metadata, ...)
+    if ("authormark" %in% names(metadata)) {
+      warning(
+        "`oup_article(oup_version = 1)` now ignores the 'authormark' field in YAML header. ",
+        "The \\authormark macro was removed from oup-authoring-template.cls v1.2 (2025-11-17); ",
+        "running heads are now set from the optional short title argument of \\title.",
+        immediate. = TRUE, call. = FALSE
+      )
+    }
+  }
+  base
 }

--- a/inst/rmarkdown/templates/oup_v1/resources/template.tex
+++ b/inst/rmarkdown/templates/oup_v1/resources/template.tex
@@ -281,6 +281,11 @@ $endif$
 % Add missing \city command mentioned in documentation but absent from cls
 \providecommand\city[1]{#1}
 
+% \authormark was removed from oup-authoring-template.cls (v1.2, 2025/11/17)
+% but is still referenced in the class' own \@@title. Define a no-op fallback
+% so documents render whether or not the upstream macro is available.
+\providecommand\authormark[1]{}
+
 % Create labels for Addresses if the are given in Elsevier format
 $for(address)$
  $if(address.code)$

--- a/inst/rmarkdown/templates/oup_v1/resources/template.tex
+++ b/inst/rmarkdown/templates/oup_v1/resources/template.tex
@@ -281,11 +281,6 @@ $endif$
 % Add missing \city command mentioned in documentation but absent from cls
 \providecommand\city[1]{#1}
 
-% \authormark was removed from oup-authoring-template.cls (v1.2, 2025/11/17)
-% but is still referenced in the class' own \@@title. Define a no-op fallback
-% so documents render whether or not the upstream macro is available.
-\providecommand\authormark[1]{}
-
 % Create labels for Addresses if the are given in Elsevier format
 $for(address)$
  $if(address.code)$
@@ -383,15 +378,6 @@ $for(author.footnote)$
 $endfor$
 
 $endfor$
-
-% Add author mark
-$if(authormark)$
-\authormark{$authormark$}
-$elseif(author)$
-\authormark{$for(author/first)$$it.name$$endfor$$if(author/rest/rest)$ et al.$else$$for(author/rest)$ \and $author.name$$endfor$$endif$}
-$elseif(authors)$
-\authormark{$for(authors/first)$$it.name$$endfor$$if(authors/rest/rest)$ et al.$else$$for(authors/rest)$ \and $authors.name$$endfor$$endif$}
-$endif$
 
 \received{Date}{0}{Year}
 \revised{Date}{0}{Year}

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,36 @@
+local_rmd_file <- function(..., .env = parent.frame()) {
+  path <- withr::local_tempfile(.local_envir = .env, fileext = ".Rmd")
+  xfun::write_utf8(c(...), path)
+  path
+}
+
+.render_and_read <- function(input, ...) {
+  skip_if_not_pandoc()
+  output_file <- withr::local_tempfile()
+  res <- rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
+  xfun::read_utf8(res)
+}
+
+# Use to test pandoc availability or version lower than
+skip_if_not_pandoc <- function(ver = NULL) {
+  if (!rmarkdown::pandoc_available(ver)) {
+    msg <- if (is.null(ver)) {
+      "Pandoc is not available"
+    } else {
+      sprintf("Version of Pandoc is lower than %s.", ver)
+    }
+    skip(msg)
+  }
+}
+
+# Use to test version greater than
+skip_if_pandoc <- function(ver = NULL) {
+  if (rmarkdown::pandoc_available(ver)) {
+    msg <- if (is.null(ver)) {
+      "Pandoc is available"
+    } else {
+      sprintf("Version of Pandoc is greater than %s.", ver)
+    }
+    skip(msg)
+  }
+}

--- a/tests/testthat/test-oup_article.R
+++ b/tests/testthat/test-oup_article.R
@@ -19,8 +19,7 @@ test_that("rmarkdown::render() actually invokes the pre_knit hook", {
   # Guards against regressions where pre_knit stops being wired into the
   # format returned by oup_article(): asserts the warning surfaces from a
   # real (knit-only, no LaTeX) render of an Rmd whose YAML sets `authormark`.
-  skip_if_not_installed("rmarkdown")
-  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  skip_if_not_pandoc("2.10")
   rmd <- withr::local_tempfile(fileext = ".Rmd")
   xfun::write_utf8(
     c(

--- a/tests/testthat/test-oup_article.R
+++ b/tests/testthat/test-oup_article.R
@@ -13,6 +13,30 @@ test_that("oup_article(oup_version = 1) does not warn for unrelated metadata", {
   )
 })
 
+test_that("rmarkdown::render() actually invokes the pre_knit hook", {
+  # Guards against regressions where pre_knit stops being wired into the
+  # format returned by oup_article(): asserts the warning surfaces from a
+  # real (knit-only, no LaTeX) render of an Rmd whose YAML sets `authormark`.
+  skip_if_not_installed("rmarkdown")
+  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  rmd <- withr::local_tempfile(fileext = ".Rmd")
+  xfun::write_utf8(c(
+    "---",
+    "title: t",
+    "authormark: \"X et al.\"",
+    "output:",
+    "  rticles::oup_article:",
+    "    oup_version: 1",
+    "---",
+    "",
+    "Body."
+  ), rmd)
+  expect_warning(
+    rmarkdown::render(rmd, quiet = TRUE, run_pandoc = FALSE),
+    regexp = "authormark"
+  )
+})
+
 test_that("oup_v1 template no longer emits \\authormark", {
   tex <- xfun::read_utf8(
     pkg_file_template("oup_v1", "resources", "template.tex")

--- a/tests/testthat/test-oup_article.R
+++ b/tests/testthat/test-oup_article.R
@@ -1,0 +1,21 @@
+test_that("oup_article(oup_version = 1) warns when `authormark` is set in YAML", {
+  fmt <- oup_article(oup_version = 1)
+  expect_warning(
+    fmt$pre_knit(input = "", metadata = list(authormark = "Anonymous et al.")),
+    regexp = "authormark"
+  )
+})
+
+test_that("oup_article(oup_version = 1) does not warn for unrelated metadata", {
+  fmt <- oup_article(oup_version = 1)
+  expect_no_warning(
+    fmt$pre_knit(input = "", metadata = list(title = "A title"))
+  )
+})
+
+test_that("oup_v1 template no longer emits \\authormark", {
+  tex <- xfun::read_utf8(
+    pkg_file_template("oup_v1", "resources", "template.tex")
+  )
+  expect_false(any(grepl("\\authormark", tex, fixed = TRUE)))
+})

--- a/tests/testthat/test-oup_article.R
+++ b/tests/testthat/test-oup_article.R
@@ -1,4 +1,5 @@
 test_that("oup_article(oup_version = 1) warns when `authormark` is set in YAML", {
+  skip_if_not_pandoc("2.10")
   fmt <- oup_article(oup_version = 1)
   expect_warning(
     fmt$pre_knit(input = "", metadata = list(authormark = "Anonymous et al.")),
@@ -7,6 +8,7 @@ test_that("oup_article(oup_version = 1) warns when `authormark` is set in YAML",
 })
 
 test_that("oup_article(oup_version = 1) does not warn for unrelated metadata", {
+  skip_if_not_pandoc("2.10")
   fmt <- oup_article(oup_version = 1)
   expect_no_warning(
     fmt$pre_knit(input = "", metadata = list(title = "A title"))
@@ -20,17 +22,20 @@ test_that("rmarkdown::render() actually invokes the pre_knit hook", {
   skip_if_not_installed("rmarkdown")
   skip_if_not(rmarkdown::pandoc_available("2.10"))
   rmd <- withr::local_tempfile(fileext = ".Rmd")
-  xfun::write_utf8(c(
-    "---",
-    "title: t",
-    "authormark: \"X et al.\"",
-    "output:",
-    "  rticles::oup_article:",
-    "    oup_version: 1",
-    "---",
-    "",
-    "Body."
-  ), rmd)
+  xfun::write_utf8(
+    c(
+      "---",
+      "title: t",
+      "authormark: \"X et al.\"",
+      "output:",
+      "  rticles::oup_article:",
+      "    oup_version: 1",
+      "---",
+      "",
+      "Body."
+    ),
+    rmd
+  )
   expect_warning(
     rmarkdown::render(rmd, quiet = TRUE, run_pandoc = FALSE),
     regexp = "authormark"


### PR DESCRIPTION
Rendering `oup_v1` (and all R-CMD-check jobs that exercise it) fails on fresh TinyTeX installs:

```
! Undefined control sequence.
l.241 \authormark
                 {Alice Anonymous et al.}
```

## Root cause

The January 3 2026 CTAN release of `oup-authoring-template` v1.2 removed the `\authormark` macro definition (the cls file's internal `\lastmodifieddate` is `2025/11/17`, but CI broke when the package was published on CTAN and TinyTeX started auto-installing the new version).

`\authormark` was an internal macro of the class, never part of its documented public API. The rticles `oup_v1` template still emitted `\authormark{...}` for the running head, so every render fails on TinyTeX (which auto-installs the latest CTAN version at render time).

The documented running-head mechanism in v1.2 is the optional argument of `\title` (`\title[short]{long}`), which the template already uses (`\title[$short_title$]{$title$}` in `template.tex:340`). That routes through `\short@title` → `\titlemark`, never through the path that calls `\authormark`. OUP's own example file on CTAN no longer references `\authormark` either.

A structural diff of v1.1 → v1.2 confirms `\authormark` is the only macro definition removed; ~40 new macros were added (sideways figures/tables, box environments, `\figalttext`, `\wordcount`, etc.), none required by our template.

## Fix

Drop the template block that emitted `\authormark{...}`. On TeX Live ≤ 2024 (cls v1.1), the only visible effect is that the even-page running head changes from "Author et al." to the short title — which is what OUP's v1.2 docs now prescribe on both pages anyway.

The YAML `authormark` key was undocumented but accepted by the Pandoc template before this change, so users who discovered it would silently lose the value after the upgrade. Add a `pre_knit` hook — mirroring the pattern in `ams_article()`, `tf_article()`, and the springer warning in `R/article.R` — that warns at render time when YAML still sets `authormark`.

## Verification

End-to-end local render with the patched template against a freshly auto-installed v1.2 cls produces a valid PDF (no LaTeX errors).

Tests added:

- Unit tests for the `pre_knit` hook (warns on `authormark`, silent on unrelated metadata).
- A render-based test (knit-only, `run_pandoc = FALSE`) covering the rmarkdown→hook wiring end-to-end.
- Regression guard asserting the template no longer contains the literal `\authormark` string.

Fixes #603